### PR TITLE
remove color printing and doxygen output on RTD

### DIFF
--- a/docs/reference_exhale_configs.rst
+++ b/docs/reference_exhale_configs.rst
@@ -714,6 +714,8 @@ Utility Variables
 
 .. autodata:: exhale.configs._app_src_dir
 
+.. autodata:: exhale.configs._on_rtd
+
 Secondary Sphinx Entry Point
 ----------------------------------------------------------------------------------------
 

--- a/exhale/configs.py
+++ b/exhale/configs.py
@@ -959,6 +959,13 @@ build process has begun to execute.  Saved to be able to run a few different san
 checks in different places.
 '''
 
+_on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+'''
+**Do not modify**.  Signals whether or not the build is taking place on ReadTheDocs.  If
+it is, then colorization of output is disabled, as well as the Doxygen output (where
+applicable) is directed to ``/dev/null`` as capturing it can cause the ``subprocess``
+buffers to overflow.
+'''
 
 ########################################################################################
 ##                                                                                     #

--- a/exhale/utils.py
+++ b/exhale/utils.py
@@ -601,7 +601,7 @@ def _use_color(msg, ansi_fmt, output_stream):
             :data:`~exhale.configs.alwaysColorize` and whether or not the
             ``output_stream`` is a TTY.
     '''
-    if not configs.alwaysColorize and not output_stream.isatty():
+    if configs._on_rtd or (not configs.alwaysColorize and not output_stream.isatty()):
         log = msg
     else:
         log = colorize(msg, ansi_fmt)
@@ -630,7 +630,7 @@ def verbose_log(msg, ansi_fmt=None):
 
 
 def __fancy(text, language, fmt):
-    if __USE_PYGMENTS:
+    if not configs._on_rtd and __USE_PYGMENTS:
         try:
             lang_lex = lexers.find_lexer_class_by_name(language)
             fmt      = formatters.get_formatter_by_name(fmt)


### PR DESCRIPTION
Fixes #14.

- colorized printing is really ugly in the online build logs
- capturing doxygen output can cause builds to fail for medium sized projects, the subprocess buffer overflows and the build will silently fail after `cat conf.py`