### PR TITLE
Stop requiring Doxyfile be next to conf.py

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@ Changelog
    :local:
    :backlinks: none
 
+v0.2.2
+----------------------------------------------------------------------------------------
+
+- Relaxe doxygen constraints for :data:`~exhale.configs.exhaleUseDoxyfile`.  Please
+  update to using string paths over specifying a boolean value.  Requring the file named
+  exactly ``Doxyfile`` to be tracked next to ``conf.py`` is not necessary.
+
 v0.2.1
 ----------------------------------------------------------------------------------------
 

--- a/docs/testing/fixtures.rst
+++ b/docs/testing/fixtures.rst
@@ -2,5 +2,4 @@ Testing Fixtures Module
 ========================================================================================
 
 .. automodule:: testing.fixtures
-
-   .. autofunction:: testing.fixtures.no_run
+   :members:

--- a/exhale/configs.py
+++ b/exhale/configs.py
@@ -904,14 +904,61 @@ exhaleUseDoxyfile = False
     use your own ``Doxyfile``.  The encouraged approach is to use
     :data:`~exhale.configs.exhaleDoxygenStdin`.
 
-**Value in** ``exhale_args`` (bool)
-    Set to ``True`` to have Exhale use your ``Doxyfile``.
+**Value in** ``exhale_args`` (bool or str)
 
-    .. note::
+    .. note:: Changed in v0.2.2: prefer ``str`` absolute or relative paths to ``bool``.
 
-       The ``Doxyfile`` must be in the **same** directory as ``conf.py``.  Exhale will
-       change directories to here before launching Doxygen when you have separate source
-       and build directories for Sphinx configured.
+    The absolute or relative (*to* ``conf.py``) path to the doxygen configuration file
+    to use.  Exhale will change directories to the directory containing this
+    configuration file.
+
+    In Exhale v0.2.1 and prior releases, the user was required to track exactly
+    ``Doxyfile`` in the same directory as ``conf.py``.  Boolean values will continue to
+    be accepted until 1.x, but users are encouraged to update now.  Updating is as
+    simple as changing
+
+    .. code-block:: py
+
+        exhale_args = {
+            # ... other configs ...
+            "exhaleUseDoxyfile": True
+        }
+
+    to be
+
+    .. code-block:: py
+
+        exhale_args = {
+            # ... other configs ...
+            "exhaleUseDoxyfile": "./Doxyfile"
+        }
+
+    Exhale is switching to string paths to avoid forcing unnecessary project layout
+    constraints on the user.  For example, if your project has the following structure
+
+    .. code-block:: none
+
+        .
+        └── docs
+            ├── build
+            │   └── html
+            │       └── index.html
+            ├── Doxyfile
+            └── source
+                └── conf.py
+
+    then you can now specify
+
+    .. code-block:: py
+
+        exhale_args = {
+            # ... other configs ...
+            "exhaleUseDoxyfile": "../Doxyfile"
+        }
+
+    This can be particularly useful if your project is configuring a Doxyfile as part of
+    the build process.
+
 
     .. warning::
 
@@ -926,8 +973,9 @@ exhaleUseDoxyfile = False
        2. ``STRIP_FROM_PATH`` is configured to be identical to what is specified with
           :data:`~exhale.configs.doxygenStripFromPath`.
 
-       I have no idea what happens when these conflict, but it likely will never result
-       in valid documentation.
+       If (1) is inconsistent, breathe will not find the documentation.  If (2) is
+       inconsistent, then typically the paths in the file hierarchy are either incorrect
+       or too long (since the path being stripped is different, nothing gets stripped).
 '''
 
 exhaleDoxygenStdin = None

--- a/exhale/configs.py
+++ b/exhale/configs.py
@@ -65,11 +65,6 @@ The |SphinxLoggerAdapter| for communicating with the sphinx build process.
 .. |SphinxLoggerAdapter| replace:: :class:`sphinx:sphinx.util.SphinxLoggerAdapter`
 """
 
-# __all__ = []
-
-__name__ = "configs"
-__docformat__ = "reStructuredText"
-
 ########################################################################################
 ##                                                                                     #
 ## Required configurations, these get set indirectly via the dictionary argument       #

--- a/exhale/deploy.py
+++ b/exhale/deploy.py
@@ -28,9 +28,6 @@ import tempfile
 import textwrap
 from subprocess import PIPE, Popen, STDOUT
 
-__name__      = "deploy"
-__docformat__ = "reStructuredText"
-
 
 def _generate_doxygen(doxygen_input):
     '''

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -30,10 +30,6 @@ except ImportError:
     # Python 3 StringIO
     from io import StringIO
 
-__all__       = ["ExhaleRoot", "ExhaleNode"]
-__name__      = "graph"
-__docformat__ = "reStructuredText"
-
 
 ########################################################################################
 #

--- a/exhale/parse.py
+++ b/exhale/parse.py
@@ -14,10 +14,6 @@ from . import utils
 import textwrap
 from bs4 import BeautifulSoup
 
-__all__       = ["walk", "convertDescriptionToRST", "getBriefAndDetailedRST"]
-__name__      = "utils"
-__docformat__ = "reStructuredText"
-
 
 def walk(textRoot, currentTag, level, prefix=None, postfix=None, unwrapUntilPara=False):
     '''

--- a/exhale/utils.py
+++ b/exhale/utils.py
@@ -28,9 +28,6 @@ try:
 except:
     __USE_PYGMENTS = False
 
-__name__      = "utils"
-__docformat__ = "reStructuredText"
-
 
 def heading_mark(title, char):
     '''

--- a/testing/__init__.py
+++ b/testing/__init__.py
@@ -24,6 +24,34 @@ See also :data:`testing.base.ExhaleTestCase.test_project`.
 """
 
 
+def docs_dir(test_project, class_name, function_name):
+    """
+    Absolute path "docs" directory for a given test case.
+
+    **Parameters**
+
+    ``test_project`` (:class:`python:str`)
+        The test project (nested directory in :data:`testing.TEST_PROJECTS_ROOT`).
+
+    ``class_name`` (:class:`python:str`)
+        The name of the test class being used.
+
+    ``function_name`` (:class:`python:str`)
+        The name of the test function (``"test_xxx"``).
+
+    **Return** (:class:`python:str`)
+        The absolute path to the "docs" directory where ``conf.py`` and friends will be
+        generated.
+    """
+    return os.path.join(
+        TEST_PROJECTS_ROOT,
+        test_project,
+        "docs_{class_name}_{function_name}".format(
+            class_name=class_name, function_name=function_name
+        )
+    )
+
+
 def get_exhale_root(test):
     """
     Return the finalized :class:`exhale.graph.ExhaleRoot` object for the specified test.

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -20,3 +20,10 @@ pytest_plugins = [
     'testing.fixtures'
 ]
 """Signals to ``pytest`` which plugins are needed for all tests."""
+
+
+def pytest_runtest_setup(item):
+    """.. todo:: stop reloading configs module in 1.x."""
+    from six.moves import reload_module
+    from exhale import configs
+    reload_module(configs)

--- a/testing/decorators.py
+++ b/testing/decorators.py
@@ -252,3 +252,33 @@ def no_run(obj):
             The decorated ``obj``.
     """
     return pytest.mark.usefixtures("no_run")(obj)
+
+
+def with_file(path, contents):
+    """
+    Create a file for a given test function and delete it afterward.
+
+    This decorator may **only** be used on ``test_*`` functions of a derived type of
+    :class:`~testing.base.ExhaleTestCase`.  The actual (contrived) mechanics are that
+    the function is marked, and a **class** level fixture that creates all requested
+    files is generated in the metaclass.  Trust me...I definitely tried to do this
+    "correctly", but this at least mostly works.
+
+    .. todo:: why can't this be used with ``@no_cleanup``
+
+    **Parameters**
+
+    ``path`` (:class:`python:str`)
+        The **absolute** path name to create the file with ``contents``.  The parent
+        directories of the file in question are **assumed** to already exist.
+
+    ``contents`` (:class:`python:str`)
+        The contents of the file to create at ``path``.
+
+    .. note::
+
+        See implementation in the metaclass, the way this works is actually
+    """
+    def with_file_decorator(func):
+        return pytest.mark.exhale_with_file(path=path, contents=contents)(func)
+    return with_file_decorator

--- a/testing/fixtures.py
+++ b/testing/fixtures.py
@@ -9,6 +9,7 @@
 Provides fixtures to be available for all test cases.
 """
 from __future__ import unicode_literals
+
 from exhale import deploy
 import pytest
 


### PR DESCRIPTION
- [x] Update docs to indicate `bool` -> `str`, encouraging users to switch now (`bool` version will be removed in 1.x).
- [ ] Add tests that use an actual `Doxyfile` and differently named.
- [ ] Add in the deferred warning stuff to tell people at the end of the build they need to stop using `bool` version.