### PR TITLE
Fix doxygen ci differently (again [again [again]])

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,23 +23,21 @@ install:
       # install python tests dependencies: doxygen, pip, tox, codecov
       if ($env:TEST_NAME -Match "py") {
         $pip_exec = $env:PYTHON + "\\python.exe"
-        $pip_args = "-m", "pip", "install", "--no-warn-script-location", "-U", "pip", "tox", "codecov", "cmake"
+        $pip_args = "-m", "pip", "install", "--no-warn-script-location", "-U", "pip", "tox", "codecov"
         & $pip_exec $pip_args
 
-        # NOTE: doxygen doesn't seem to work with latest cmake // ninja :/
-        choco install winflexbison
+        # Fetch the pre-compiled binary release for doxygen directly.
         mkdir doxygen
         cd doxygen
-        $doxy_src = "https://github.com/doxygen/doxygen/archive/Release_1_8_14.zip"
-        $doxy_dst = "c:\projects\exhale\doxygen\Release_1_8_14.zip"
-        Invoke-WebRequest $doxy_src -OutFile $doxy_dst
-        7z x Release_1_8_14.zip
-        cd doxygen-Release_1_8_14
-        mkdir build
-        cd build
-        cmake -G "Visual Studio 15 2017" .. -DCMAKE_INSTALL_PREFIX="c:\projects\exhale\doxygen"
-        cmake --build . --config Release --target install
-        $env:Path += ";c:\projects\exhale\doxygen\bin"
+        $doxy_src = "https://sourceforge.net/projects/doxygen/files/rel-1.8.14/doxygen-1.8.14.windows.x64.bin.zip"
+        $doxy_dst = "c:\projects\exhale\doxygen\doxygen-1.8.14.windows.x64.bin.zip"
+        # Needs -UserAgent "NativeHost" to follow sourceforge redirects
+        Invoke-WebRequest -Uri $doxy_src -OutFile $doxy_dst -UserAgent "NativeHost"
+        # Extracts `doxygen.exe`, `doxyindexer.exe`, `doxysearch.cgi.exe`, and
+        # `libclang.dll` to same directory aka c:\projects\exhale\doxygen\doxygen.exe
+        # is what we want to use.
+        7z x doxygen-1.8.14.windows.x64.bin.zip
+        $env:Path += ";c:\projects\exhale\doxygen"
       }
       # install cxx tests dependencies: pip, codecov, opencppcoverage
       else {

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -94,6 +94,6 @@ after_test:
         Invoke-Expression $codecov_cmd
       }
       else {
-        $codecov_cmd = '& codecov -X gcov -f .\coverage.xml --name ' + $env:TEST_NAME
+        $codecov_cmd = '& codecov -X gcov -f c:\projects\exhale\coverage.xml --name ' + $env:TEST_NAME
         Invoke-Expression $codecov_cmd
       }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,11 +50,9 @@ intersphinx_mapping = {
     'bs4':    ('https://www.crummy.com/software/BeautifulSoup/bs4/doc', "_intersphinx/bs4_objects.inv")
 }
 
+# make linkcheck does not support GitHub README.md anchors (they are synthetic anchors)
 linkcheck_ignore = [
-    # linkcheck does not support GitHub README.md anchors (they are synthetic anchors)
-    r'https://github\.com/jonmiles/bootstrap-treeview#.*',
-    # frequent outages on doxygen website, annoying enough that I don't care anymore
-    r'.*www\.stack\.nl/~dimitri/doxygen.*'
+    r'https://github.com/jonmiles/bootstrap-treeview#.*'
 ]
 
 # show :autoclass: member definitions as defined in exhale.py

--- a/docs/mastering_doxygen.rst
+++ b/docs/mastering_doxygen.rst
@@ -20,7 +20,7 @@ What is Doxygen, and How do I Approach it?
 `Doxygen`__ is a documentation (doxy) generation (gen) system.  You should approach it
 with fear, awe, and humility.  And remember to never look it in the eyes.
 
-__ http://www.stack.nl/~dimitri/doxygen/
+__ http://www.doxygen.nl/
 
 Doxygen on its own is a fascinating tool.  It's stupendously flexible, and immensely
 powerful.  I mean let's think about what it's actually doing: it's parsing and
@@ -68,7 +68,7 @@ overwhelming) approach of just reading the entire generated ``Doxyfile``.  You c
 acquire a shiny new ``Doxyfile`` by executing ``doxygen -g`` in your terminal in a
 directory where there is no ``Doxyfile`` present.
 
-__ http://www.stack.nl/~dimitri/doxygen/manual/index.html
+__ http://www.doxygen.nl/manual/index.html
 
 .. tip::
 
@@ -321,7 +321,7 @@ documenting specific aspects:
 | ``\c``          | Teletype a single word (e.g. ``\c computeroutput``).               |
 +-----------------+--------------------------------------------------------------------+
 
-__ http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html
+__ http://www.doxygen.nl/manual/docblocks.html
 
 Doxygen Documentation Pitfalls
 ----------------------------------------------------------------------------------------
@@ -342,7 +342,7 @@ documentation is empty)!  From the Doxygen documentation reiteration_:
     (functions, typedefs, enum, macros, etc), you must document the file in which they
     are defined.
 
-.. _reiteration: http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html
+.. _reiteration: http://www.doxygen.nl/manual/docblocks.html
 
 .. _file_associations:
 
@@ -350,7 +350,8 @@ Associating Documentation with the Right File
 ****************************************************************************************
 
 Classes, Structs, Enums, and Unions typically need additional care in order for them to
-appear in the hierarchy correctly.  If you have a file in a directory, the Doxygen FAQ_ explains that you need to specify this location:
+appear in the hierarchy correctly.  If you have a file in a directory, the Doxygen FAQ_
+explains that you need to specify this location:
 
 ..
 
@@ -382,7 +383,7 @@ might look like:
         thing() {}
      };
 
-.. _FAQ: http://www.stack.nl/~dimitri/doxygen/manual/faq.html#faq_code_inc
+.. _FAQ: http://www.doxygen.nl/manual/faq.html#faq_code_inc
 
 Features Available by Using Sphinx / Breathe / Exhale by way of reStructuredText
 ----------------------------------------------------------------------------------------

--- a/exhale/parse.py
+++ b/exhale/parse.py
@@ -44,9 +44,9 @@ def walk(textRoot, currentTag, level, prefix=None, postfix=None, unwrapUntilPara
     - ``computeroutput`` (e.g., using `c`_)
     - ``bold`` (e.g., using `b`_)
 
-    .. _em: http://www.stack.nl/~dimitri/doxygen/manual/commands.html#cmdem
-    .. _c:  http://www.stack.nl/~dimitri/doxygen/manual/commands.html#cmdc
-    .. _b:  http://www.stack.nl/~dimitri/doxygen/manual/commands.html#cmdb
+    .. _em: http://www.doxygen.nl/manual/commands.html#cmdem
+    .. _c:  http://www.doxygen.nl/manual/commands.html#cmdc
+    .. _b:  http://www.doxygen.nl/manual/commands.html#cmdb
 
     The goal of this method is to "explode" input ``xml`` data into raw reStructuredText
     to put at the top of the file pages.  Wielding beautiful soup, this essentially


### PR DESCRIPTION
Fixes #55.

- [X] Fix the doxygen links to use `doxygen.nl` since `stack.nl/~dimitri/doxygen` gives 403 again.  This appears to be the official site since `doxygen.org` redirects to `doxygen.nl`?
- [X] Use binary installers from sourceforge on Windows.  Not linux because they didn't compile anything statically aka they're definitely not ummmm...distributable...
- [X] Bonus: fix an apparent regression with codecov on AppVeyor.