### PR TITLE
repair testing suite to still test with py2.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,104 +1,104 @@
-# # If branch from same repo is on a PR, don't build both :)
-# skip_branch_with_pr: true
-# image: Visual Studio 2017
-# clone_folder: C:\projects\exhale
+# If branch from same repo is on a PR, don't build both :)
+skip_branch_with_pr: true
+image: Visual Studio 2017
+clone_folder: C:\projects\exhale
 
-# # See: https://packaging.python.org/guides/supporting-windows-using-appveyor/
-# environment:
-#   matrix:
-#     - PYTHON:    "C:\\Python27"
-#       TEST_NAME: "win32_py27"
-#       SPHINX_VERSION: "1.8.5"
-#       BREATHE_VERSION: "4.12.0"
-#     - PYTHON:    "C:\\Python27-x64"
-#       TEST_NAME: "win64_py27"
-#       SPHINX_VERSION: "1.8.5"
-#       BREATHE_VERSION: "4.12.0"
-#     # Use latest sphinx / breathe (see also: tox.ini)
-#     - PYTHON:    "C:\\Python36-x64"
-#       TEST_NAME: "win64_py36"
-#     - PYTHON:    "C:\\Python36-x64"
-#       TEST_NAME: "win64_cxx"
+# See: https://packaging.python.org/guides/supporting-windows-using-appveyor/
+environment:
+  matrix:
+    - PYTHON:    "C:\\Python27"
+      TEST_NAME: "win32_py27"
+      SPHINX_VERSION: "1.8.5"
+      BREATHE_VERSION: "4.12.0"
+    - PYTHON:    "C:\\Python27-x64"
+      TEST_NAME: "win64_py27"
+      SPHINX_VERSION: "1.8.5"
+      BREATHE_VERSION: "4.12.0"
+    # Use latest sphinx / breathe (see also: tox.ini)
+    - PYTHON:    "C:\\Python36-x64"
+      TEST_NAME: "win64_py36"
+    - PYTHON:    "C:\\Python36-x64"
+      TEST_NAME: "win64_cxx"
 
-# install:
-#   - ps: |
-#       # Make it so codecov etc can be found
-#       $env:Path += ";" + $env:PYTHON + "\\Scripts"
+install:
+  - ps: |
+      # Make it so codecov etc can be found
+      $env:Path += ";" + $env:PYTHON + "\\Scripts"
 
-#       # install python tests dependencies: doxygen, pip, tox, codecov
-#       if ($env:TEST_NAME -Match "py") {
-#         $pip_exec = $env:PYTHON + "\\python.exe"
-#         $pip_args = "-m", "pip", "install", "--no-warn-script-location", "-U", "pip", "tox", "codecov"
-#         & $pip_exec $pip_args
+      # install python tests dependencies: doxygen, pip, tox, codecov
+      if ($env:TEST_NAME -Match "py") {
+        $pip_exec = $env:PYTHON + "\\python.exe"
+        $pip_args = "-m", "pip", "install", "--no-warn-script-location", "-U", "pip", "tox", "codecov"
+        & $pip_exec $pip_args
 
-#         # Fetch the pre-compiled binary release for doxygen directly.
-#         mkdir doxygen
-#         cd doxygen
-#         $doxy_src = "https://sourceforge.net/projects/doxygen/files/rel-1.8.14/doxygen-1.8.14.windows.x64.bin.zip"
-#         $doxy_dst = "c:\projects\exhale\doxygen\doxygen-1.8.14.windows.x64.bin.zip"
-#         # Needs -UserAgent "NativeHost" to follow sourceforge redirects
-#         Invoke-WebRequest -Uri $doxy_src -OutFile $doxy_dst -UserAgent "NativeHost"
-#         # Extracts `doxygen.exe`, `doxyindexer.exe`, `doxysearch.cgi.exe`, and
-#         # `libclang.dll` to same directory aka c:\projects\exhale\doxygen\doxygen.exe
-#         # is what we want to use.
-#         7z x doxygen-1.8.14.windows.x64.bin.zip
-#         $env:Path += ";c:\projects\exhale\doxygen"
-#       }
-#       # install cxx tests dependencies: pip, codecov, opencppcoverage
-#       else {
-#         $pip_exec = $env:PYTHON + "\\python.exe"
-#         $pip_args = "-m", "pip", "install", "--no-warn-script-location", "-U", "pip", "codecov"
-#         & $pip_exec $pip_args
+        # Fetch the pre-compiled binary release for doxygen directly.
+        mkdir doxygen
+        cd doxygen
+        $doxy_src = "https://sourceforge.net/projects/doxygen/files/rel-1.8.14/doxygen-1.8.14.windows.x64.bin.zip"
+        $doxy_dst = "c:\projects\exhale\doxygen\doxygen-1.8.14.windows.x64.bin.zip"
+        # Needs -UserAgent "NativeHost" to follow sourceforge redirects
+        Invoke-WebRequest -Uri $doxy_src -OutFile $doxy_dst -UserAgent "NativeHost"
+        # Extracts `doxygen.exe`, `doxyindexer.exe`, `doxysearch.cgi.exe`, and
+        # `libclang.dll` to same directory aka c:\projects\exhale\doxygen\doxygen.exe
+        # is what we want to use.
+        7z x doxygen-1.8.14.windows.x64.bin.zip
+        $env:Path += ";c:\projects\exhale\doxygen"
+      }
+      # install cxx tests dependencies: pip, codecov, opencppcoverage
+      else {
+        $pip_exec = $env:PYTHON + "\\python.exe"
+        $pip_args = "-m", "pip", "install", "--no-warn-script-location", "-U", "pip", "codecov"
+        & $pip_exec $pip_args
 
-#         choco install --no-progress opencppcoverage
-#         $env:Path += ";" + "C:\Program Files\OpenCppCoverage"
-#       }
+        choco install --no-progress opencppcoverage
+        $env:Path += ";" + "C:\Program Files\OpenCppCoverage"
+      }
 
-# build: off
+build: off
 
-# test_script:
-#   - ps: |
-#       if ($env:TEST_NAME -Match "py") {
-#         # Prints setuptools version
-#         easy_install --version
+test_script:
+  - ps: |
+      if ($env:TEST_NAME -Match "py") {
+        # Prints setuptools version
+        easy_install --version
 
-#         # Print doxygen version
-#         Write-Host "Doxygen version:"
-#         doxygen --version
+        # Print doxygen version
+        Write-Host "Doxygen version:"
+        doxygen --version
 
-#         # Installs dependencies and runs the tests.
-#         $tox_exec = $env:PYTHON + "\\Scripts\\tox"
-#         $tox_args = "-e", "py", "--", "--cov-report", "xml:coverage.xml", "--cov"
-#         & $tox_exec $tox_args
-#       }
-#       else {
-#         cd testing\projects
-#         mkdir build
-#         cd build
-#         cmake -G "Visual Studio 15 2017" ..
-#         cmake --build .
-#         cmake --build . --target coverage-xml
-#       }
+        # Installs dependencies and runs the tests.
+        $tox_exec = $env:PYTHON + "\\Scripts\\tox"
+        $tox_args = "-e", "py", "--", "--cov-report", "xml:coverage.xml", "--cov"
+        & $tox_exec $tox_args
+      }
+      else {
+        cd testing\projects
+        mkdir build
+        cd build
+        cmake -G "Visual Studio 15 2017" ..
+        cmake --build .
+        cmake --build . --target coverage-xml
+      }
 
-# # Why use Invoke-Expression like this?  Because I keep getting
-# #
-# #   codecov : The filename, directory name, or volume label syntax is incorrect.
-# #
-# # Which reports the build as failed, but Invoke-Expression always succeeds xD
-# after_test:
-#   - ps: |
-#       if ($env:TEST_NAME -Match "cxx") {
-#         # Gerrymander generated coverage report to include paths from the repository
-#         # root (rather than let AppVeyor build folder paths leak in).
-#         # Take note of two things: (1) no C:\\ at beginning, and (2) clone_folder above
-#         (Get-Content .\coverage.xml) -replace '(.*)filename=\"projects\\exhale\\(.*)\"(.*)', '$1 filename="$2"$3' | Set-Content .\coverage.xml
-#         Copy-Item .\coverage.xml -Destination C:\projects\exhale
-#         cd C:\projects\exhale
+# Why use Invoke-Expression like this?  Because I keep getting
+#
+#   codecov : The filename, directory name, or volume label syntax is incorrect.
+#
+# Which reports the build as failed, but Invoke-Expression always succeeds xD
+after_test:
+  - ps: |
+      if ($env:TEST_NAME -Match "cxx") {
+        # Gerrymander generated coverage report to include paths from the repository
+        # root (rather than let AppVeyor build folder paths leak in).
+        # Take note of two things: (1) no C:\\ at beginning, and (2) clone_folder above
+        (Get-Content .\coverage.xml) -replace '(.*)filename=\"projects\\exhale\\(.*)\"(.*)', '$1 filename="$2"$3' | Set-Content .\coverage.xml
+        Copy-Item .\coverage.xml -Destination C:\projects\exhale
+        cd C:\projects\exhale
 
-#         $codecov_cmd = '& codecov -X gcov -f .\coverage.xml --name ' + $env:TEST_NAME
-#         Invoke-Expression $codecov_cmd
-#       }
-#       else {
-#         $codecov_cmd = '& codecov -X gcov -f c:\projects\exhale\coverage.xml --name ' + $env:TEST_NAME
-#         Invoke-Expression $codecov_cmd
-#       }
+        $codecov_cmd = '& codecov -X gcov -f .\coverage.xml --name ' + $env:TEST_NAME
+        Invoke-Expression $codecov_cmd
+      }
+      else {
+        $codecov_cmd = '& codecov -X gcov -f c:\projects\exhale\coverage.xml --name ' + $env:TEST_NAME
+        Invoke-Expression $codecov_cmd
+      }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,8 +8,13 @@ environment:
   matrix:
     - PYTHON:    "C:\\Python27"
       TEST_NAME: "win32_py27"
+      SPHINX_VERSION: "1.8.5"
+      BREATHE_VERSION: "4.12.0"
     - PYTHON:    "C:\\Python27-x64"
       TEST_NAME: "win64_py27"
+      SPHINX_VERSION: "1.8.5"
+      BREATHE_VERSION: "4.12.0"
+    # Use latest sphinx / breathe (see also: tox.ini)
     - PYTHON:    "C:\\Python36-x64"
       TEST_NAME: "win64_py36"
     - PYTHON:    "C:\\Python36-x64"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,14 +34,14 @@ install:
         # Fetch the pre-compiled binary release for doxygen directly.
         mkdir doxygen
         cd doxygen
-        $doxy_src = "https://sourceforge.net/projects/doxygen/files/rel-1.8.14/doxygen-1.8.14.windows.x64.bin.zip"
-        $doxy_dst = "c:\projects\exhale\doxygen\doxygen-1.8.14.windows.x64.bin.zip"
+        $doxy_src = "https://sourceforge.net/projects/doxygen/files/rel-1.8.15/doxygen-1.8.15.windows.x64.bin.zip"
+        $doxy_dst = "c:\projects\exhale\doxygen\doxygen-1.8.15.windows.x64.bin.zip"
         # Needs -UserAgent "NativeHost" to follow sourceforge redirects
         Invoke-WebRequest -Uri $doxy_src -OutFile $doxy_dst -UserAgent "NativeHost"
         # Extracts `doxygen.exe`, `doxyindexer.exe`, `doxysearch.cgi.exe`, and
         # `libclang.dll` to same directory aka c:\projects\exhale\doxygen\doxygen.exe
         # is what we want to use.
-        7z x doxygen-1.8.14.windows.x64.bin.zip
+        7z x doxygen-1.8.15.windows.x64.bin.zip
         $env:Path += ";c:\projects\exhale\doxygen"
       }
       # install cxx tests dependencies: pip, codecov, opencppcoverage

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,104 +1,104 @@
-# If branch from same repo is on a PR, don't build both :)
-skip_branch_with_pr: true
-image: Visual Studio 2017
-clone_folder: C:\projects\exhale
+# # If branch from same repo is on a PR, don't build both :)
+# skip_branch_with_pr: true
+# image: Visual Studio 2017
+# clone_folder: C:\projects\exhale
 
-# See: https://packaging.python.org/guides/supporting-windows-using-appveyor/
-environment:
-  matrix:
-    - PYTHON:    "C:\\Python27"
-      TEST_NAME: "win32_py27"
-      SPHINX_VERSION: "1.8.5"
-      BREATHE_VERSION: "4.12.0"
-    - PYTHON:    "C:\\Python27-x64"
-      TEST_NAME: "win64_py27"
-      SPHINX_VERSION: "1.8.5"
-      BREATHE_VERSION: "4.12.0"
-    # Use latest sphinx / breathe (see also: tox.ini)
-    - PYTHON:    "C:\\Python36-x64"
-      TEST_NAME: "win64_py36"
-    - PYTHON:    "C:\\Python36-x64"
-      TEST_NAME: "win64_cxx"
+# # See: https://packaging.python.org/guides/supporting-windows-using-appveyor/
+# environment:
+#   matrix:
+#     - PYTHON:    "C:\\Python27"
+#       TEST_NAME: "win32_py27"
+#       SPHINX_VERSION: "1.8.5"
+#       BREATHE_VERSION: "4.12.0"
+#     - PYTHON:    "C:\\Python27-x64"
+#       TEST_NAME: "win64_py27"
+#       SPHINX_VERSION: "1.8.5"
+#       BREATHE_VERSION: "4.12.0"
+#     # Use latest sphinx / breathe (see also: tox.ini)
+#     - PYTHON:    "C:\\Python36-x64"
+#       TEST_NAME: "win64_py36"
+#     - PYTHON:    "C:\\Python36-x64"
+#       TEST_NAME: "win64_cxx"
 
-install:
-  - ps: |
-      # Make it so codecov etc can be found
-      $env:Path += ";" + $env:PYTHON + "\\Scripts"
+# install:
+#   - ps: |
+#       # Make it so codecov etc can be found
+#       $env:Path += ";" + $env:PYTHON + "\\Scripts"
 
-      # install python tests dependencies: doxygen, pip, tox, codecov
-      if ($env:TEST_NAME -Match "py") {
-        $pip_exec = $env:PYTHON + "\\python.exe"
-        $pip_args = "-m", "pip", "install", "--no-warn-script-location", "-U", "pip", "tox", "codecov"
-        & $pip_exec $pip_args
+#       # install python tests dependencies: doxygen, pip, tox, codecov
+#       if ($env:TEST_NAME -Match "py") {
+#         $pip_exec = $env:PYTHON + "\\python.exe"
+#         $pip_args = "-m", "pip", "install", "--no-warn-script-location", "-U", "pip", "tox", "codecov"
+#         & $pip_exec $pip_args
 
-        # Fetch the pre-compiled binary release for doxygen directly.
-        mkdir doxygen
-        cd doxygen
-        $doxy_src = "https://sourceforge.net/projects/doxygen/files/rel-1.8.14/doxygen-1.8.14.windows.x64.bin.zip"
-        $doxy_dst = "c:\projects\exhale\doxygen\doxygen-1.8.14.windows.x64.bin.zip"
-        # Needs -UserAgent "NativeHost" to follow sourceforge redirects
-        Invoke-WebRequest -Uri $doxy_src -OutFile $doxy_dst -UserAgent "NativeHost"
-        # Extracts `doxygen.exe`, `doxyindexer.exe`, `doxysearch.cgi.exe`, and
-        # `libclang.dll` to same directory aka c:\projects\exhale\doxygen\doxygen.exe
-        # is what we want to use.
-        7z x doxygen-1.8.14.windows.x64.bin.zip
-        $env:Path += ";c:\projects\exhale\doxygen"
-      }
-      # install cxx tests dependencies: pip, codecov, opencppcoverage
-      else {
-        $pip_exec = $env:PYTHON + "\\python.exe"
-        $pip_args = "-m", "pip", "install", "--no-warn-script-location", "-U", "pip", "codecov"
-        & $pip_exec $pip_args
+#         # Fetch the pre-compiled binary release for doxygen directly.
+#         mkdir doxygen
+#         cd doxygen
+#         $doxy_src = "https://sourceforge.net/projects/doxygen/files/rel-1.8.14/doxygen-1.8.14.windows.x64.bin.zip"
+#         $doxy_dst = "c:\projects\exhale\doxygen\doxygen-1.8.14.windows.x64.bin.zip"
+#         # Needs -UserAgent "NativeHost" to follow sourceforge redirects
+#         Invoke-WebRequest -Uri $doxy_src -OutFile $doxy_dst -UserAgent "NativeHost"
+#         # Extracts `doxygen.exe`, `doxyindexer.exe`, `doxysearch.cgi.exe`, and
+#         # `libclang.dll` to same directory aka c:\projects\exhale\doxygen\doxygen.exe
+#         # is what we want to use.
+#         7z x doxygen-1.8.14.windows.x64.bin.zip
+#         $env:Path += ";c:\projects\exhale\doxygen"
+#       }
+#       # install cxx tests dependencies: pip, codecov, opencppcoverage
+#       else {
+#         $pip_exec = $env:PYTHON + "\\python.exe"
+#         $pip_args = "-m", "pip", "install", "--no-warn-script-location", "-U", "pip", "codecov"
+#         & $pip_exec $pip_args
 
-        choco install --no-progress opencppcoverage
-        $env:Path += ";" + "C:\Program Files\OpenCppCoverage"
-      }
+#         choco install --no-progress opencppcoverage
+#         $env:Path += ";" + "C:\Program Files\OpenCppCoverage"
+#       }
 
-build: off
+# build: off
 
-test_script:
-  - ps: |
-      if ($env:TEST_NAME -Match "py") {
-        # Prints setuptools version
-        easy_install --version
+# test_script:
+#   - ps: |
+#       if ($env:TEST_NAME -Match "py") {
+#         # Prints setuptools version
+#         easy_install --version
 
-        # Print doxygen version
-        Write-Host "Doxygen version:"
-        doxygen --version
+#         # Print doxygen version
+#         Write-Host "Doxygen version:"
+#         doxygen --version
 
-        # Installs dependencies and runs the tests.
-        $tox_exec = $env:PYTHON + "\\Scripts\\tox"
-        $tox_args = "-e", "py", "--", "--cov-report", "xml:coverage.xml", "--cov"
-        & $tox_exec $tox_args
-      }
-      else {
-        cd testing\projects
-        mkdir build
-        cd build
-        cmake -G "Visual Studio 15 2017" ..
-        cmake --build .
-        cmake --build . --target coverage-xml
-      }
+#         # Installs dependencies and runs the tests.
+#         $tox_exec = $env:PYTHON + "\\Scripts\\tox"
+#         $tox_args = "-e", "py", "--", "--cov-report", "xml:coverage.xml", "--cov"
+#         & $tox_exec $tox_args
+#       }
+#       else {
+#         cd testing\projects
+#         mkdir build
+#         cd build
+#         cmake -G "Visual Studio 15 2017" ..
+#         cmake --build .
+#         cmake --build . --target coverage-xml
+#       }
 
-# Why use Invoke-Expression like this?  Because I keep getting
-#
-#   codecov : The filename, directory name, or volume label syntax is incorrect.
-#
-# Which reports the build as failed, but Invoke-Expression always succeeds xD
-after_test:
-  - ps: |
-      if ($env:TEST_NAME -Match "cxx") {
-        # Gerrymander generated coverage report to include paths from the repository
-        # root (rather than let AppVeyor build folder paths leak in).
-        # Take note of two things: (1) no C:\\ at beginning, and (2) clone_folder above
-        (Get-Content .\coverage.xml) -replace '(.*)filename=\"projects\\exhale\\(.*)\"(.*)', '$1 filename="$2"$3' | Set-Content .\coverage.xml
-        Copy-Item .\coverage.xml -Destination C:\projects\exhale
-        cd C:\projects\exhale
+# # Why use Invoke-Expression like this?  Because I keep getting
+# #
+# #   codecov : The filename, directory name, or volume label syntax is incorrect.
+# #
+# # Which reports the build as failed, but Invoke-Expression always succeeds xD
+# after_test:
+#   - ps: |
+#       if ($env:TEST_NAME -Match "cxx") {
+#         # Gerrymander generated coverage report to include paths from the repository
+#         # root (rather than let AppVeyor build folder paths leak in).
+#         # Take note of two things: (1) no C:\\ at beginning, and (2) clone_folder above
+#         (Get-Content .\coverage.xml) -replace '(.*)filename=\"projects\\exhale\\(.*)\"(.*)', '$1 filename="$2"$3' | Set-Content .\coverage.xml
+#         Copy-Item .\coverage.xml -Destination C:\projects\exhale
+#         cd C:\projects\exhale
 
-        $codecov_cmd = '& codecov -X gcov -f .\coverage.xml --name ' + $env:TEST_NAME
-        Invoke-Expression $codecov_cmd
-      }
-      else {
-        $codecov_cmd = '& codecov -X gcov -f c:\projects\exhale\coverage.xml --name ' + $env:TEST_NAME
-        Invoke-Expression $codecov_cmd
-      }
+#         $codecov_cmd = '& codecov -X gcov -f .\coverage.xml --name ' + $env:TEST_NAME
+#         Invoke-Expression $codecov_cmd
+#       }
+#       else {
+#         $codecov_cmd = '& codecov -X gcov -f c:\projects\exhale\coverage.xml --name ' + $env:TEST_NAME
+#         Invoke-Expression $codecov_cmd
+#       }

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
       # Use latest sphinx / breathe (see also: tox.ini)
       env: PY=3.6 HOMEBREW_NO_AUTO_UPDATE=1
       before_install:
-        - brew upgrade python
+        - brew upgrade python || true
       install:
         - brew install doxygen
         - /usr/local/bin/pip3 install -U tox codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ matrix:
     ####################################################################################
     - os: osx
       language: generic
-      env: PY=2.7 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0
+      env: PY=2.7 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0 HOMEBREW_NO_AUTO_UPDATE=1
       before_install:
         # Something strange about final step of install gives exit code != 1 but the
         # installation appears to work?
@@ -85,7 +85,7 @@ matrix:
     - os: osx
       language: generic
       # Use latest sphinx / breathe (see also: tox.ini)
-      env: PY=3.6
+      env: PY=3.6 HOMEBREW_NO_AUTO_UPDATE=1
       before_install:
         - brew upgrade python
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,85 +44,85 @@ matrix:
   allow_failures:
     - env: ALLOW_ME_TO=FAIL
   include:
-    ####################################################################################
-    # Linux :: Python :: 2.7                                                           #
-    ####################################################################################
-    - <<: *linux_specs
-      python: "2.7"
-      env: PY=2.7 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0
-    ####################################################################################
-    # Linux :: Python :: 3.6                                                           #
-    ####################################################################################
-    - <<: *linux_specs
-      python: "3.6"
-      env: PY=3.6 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0
-      # Use latest sphinx / breathe (see also: tox.ini)
-    - <<: *linux_specs
-      python: "3.6"
-      env: PY=3.6
-    ####################################################################################
-    # OSX :: Python :: 2.7                                                             #
-    ####################################################################################
-    - os: osx
-      language: generic
-      env: PY=2.7 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0 HOMEBREW_NO_AUTO_UPDATE=1
-      before_install:
-        # Something strange about final step of install gives exit code != 1 but the
-        # installation appears to work?
-        - brew install python@2 || true
-      install:
-        - brew install doxygen
-        - /usr/local/bin/pip install -U tox codecov
-      script:
-        - doxygen --version
-        - /usr/local/bin/python2 --version
-        - /usr/local/bin/python2 -m tox -e py -- --cov-report xml:coverage.xml --cov
-      after_success:
-        - codecov -X gcov -f coverage.xml --name osx_py2.7
-    ####################################################################################
-    # OSX :: Python :: 3.6                                                             #
-    ####################################################################################
-    - os: osx
-      language: generic
-      # Use latest sphinx / breathe (see also: tox.ini)
-      env: PY=3.6 HOMEBREW_NO_AUTO_UPDATE=1
-      before_install:
-        - brew upgrade python || true
-      install:
-        - brew install doxygen
-        - /usr/local/bin/pip3 install -U tox codecov
-      script:
-        - doxygen --version
-        - /usr/local/bin/python3 --version
-        - /usr/local/bin/python3 -m tox -e py -- --cov-report xml:coverage.xml --cov
-      after_success:
-        - codecov -X gcov -f coverage.xml --name osx_py3.6
-    ####################################################################################
-    # Flake8                                                                           #
-    ####################################################################################
-    - os: linux
-      language: python
-      env: TEST=flake8
-      python: "3.6"
-      install:
-        - pip install -U tox
-      script:
-        - tox -e flake8
-    ####################################################################################
-    # Docs and Linkcheck                                                               #
-    ####################################################################################
-    - os: linux
-      addons:
-        apt:
-          packages:
-            - graphviz
-      language: python
-      python: "3.6"
-      env: TEST=docs_linkcheck
-      install:
-        - pip install -U tox
-      script:
-        - tox -e docs,linkcheck
+    # ####################################################################################
+    # # Linux :: Python :: 2.7                                                           #
+    # ####################################################################################
+    # - <<: *linux_specs
+    #   python: "2.7"
+    #   env: PY=2.7 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0
+    # ####################################################################################
+    # # Linux :: Python :: 3.6                                                           #
+    # ####################################################################################
+    # - <<: *linux_specs
+    #   python: "3.6"
+    #   env: PY=3.6 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0
+    #   # Use latest sphinx / breathe (see also: tox.ini)
+    # - <<: *linux_specs
+    #   python: "3.6"
+    #   env: PY=3.6
+    # ####################################################################################
+    # # OSX :: Python :: 2.7                                                             #
+    # ####################################################################################
+    # - os: osx
+    #   language: generic
+    #   env: PY=2.7 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0 HOMEBREW_NO_AUTO_UPDATE=1
+    #   before_install:
+    #     # Something strange about final step of install gives exit code != 1 but the
+    #     # installation appears to work?
+    #     - brew install python@2 || true
+    #   install:
+    #     - brew install doxygen
+    #     - /usr/local/bin/pip install -U tox codecov
+    #   script:
+    #     - doxygen --version
+    #     - /usr/local/bin/python2 --version
+    #     - /usr/local/bin/python2 -m tox -e py -- --cov-report xml:coverage.xml --cov
+    #   after_success:
+    #     - codecov -X gcov -f coverage.xml --name osx_py2.7
+    # ####################################################################################
+    # # OSX :: Python :: 3.6                                                             #
+    # ####################################################################################
+    # - os: osx
+    #   language: generic
+    #   # Use latest sphinx / breathe (see also: tox.ini)
+    #   env: PY=3.6 HOMEBREW_NO_AUTO_UPDATE=1
+    #   before_install:
+    #     - brew upgrade python || true
+    #   install:
+    #     - brew install doxygen
+    #     - /usr/local/bin/pip3 install -U tox codecov
+    #   script:
+    #     - doxygen --version
+    #     - /usr/local/bin/python3 --version
+    #     - /usr/local/bin/python3 -m tox -e py -- --cov-report xml:coverage.xml --cov
+    #   after_success:
+    #     - codecov -X gcov -f coverage.xml --name osx_py3.6
+    # ####################################################################################
+    # # Flake8                                                                           #
+    # ####################################################################################
+    # - os: linux
+    #   language: python
+    #   env: TEST=flake8
+    #   python: "3.6"
+    #   install:
+    #     - pip install -U tox
+    #   script:
+    #     - tox -e flake8
+    # ####################################################################################
+    # # Docs and Linkcheck                                                               #
+    # ####################################################################################
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       packages:
+    #         - graphviz
+    #   language: python
+    #   python: "3.6"
+    #   env: TEST=docs_linkcheck
+    #   install:
+    #     - pip install -U tox
+    #   script:
+    #     - tox -e docs,linkcheck
     ####################################################################################
     # testing/projects Code Validation                                                 #
     ####################################################################################
@@ -136,6 +136,7 @@ matrix:
             - g++-7
             - gfortran-7
             - python3.5
+            - python3.5-dev
             - python3.5-venv
             - cmake
       language: cpp  # mostly ;)

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,85 +44,85 @@ matrix:
   allow_failures:
     - env: ALLOW_ME_TO=FAIL
   include:
-    # ####################################################################################
-    # # Linux :: Python :: 2.7                                                           #
-    # ####################################################################################
-    # - <<: *linux_specs
-    #   python: "2.7"
-    #   env: PY=2.7 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0
-    # ####################################################################################
-    # # Linux :: Python :: 3.6                                                           #
-    # ####################################################################################
-    # - <<: *linux_specs
-    #   python: "3.6"
-    #   env: PY=3.6 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0
-    #   # Use latest sphinx / breathe (see also: tox.ini)
-    # - <<: *linux_specs
-    #   python: "3.6"
-    #   env: PY=3.6
-    # ####################################################################################
-    # # OSX :: Python :: 2.7                                                             #
-    # ####################################################################################
-    # - os: osx
-    #   language: generic
-    #   env: PY=2.7 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0 HOMEBREW_NO_AUTO_UPDATE=1
-    #   before_install:
-    #     # Something strange about final step of install gives exit code != 1 but the
-    #     # installation appears to work?
-    #     - brew install python@2 || true
-    #   install:
-    #     - brew install doxygen
-    #     - /usr/local/bin/pip install -U tox codecov
-    #   script:
-    #     - doxygen --version
-    #     - /usr/local/bin/python2 --version
-    #     - /usr/local/bin/python2 -m tox -e py -- --cov-report xml:coverage.xml --cov
-    #   after_success:
-    #     - codecov -X gcov -f coverage.xml --name osx_py2.7
-    # ####################################################################################
-    # # OSX :: Python :: 3.6                                                             #
-    # ####################################################################################
-    # - os: osx
-    #   language: generic
-    #   # Use latest sphinx / breathe (see also: tox.ini)
-    #   env: PY=3.6 HOMEBREW_NO_AUTO_UPDATE=1
-    #   before_install:
-    #     - brew upgrade python || true
-    #   install:
-    #     - brew install doxygen
-    #     - /usr/local/bin/pip3 install -U tox codecov
-    #   script:
-    #     - doxygen --version
-    #     - /usr/local/bin/python3 --version
-    #     - /usr/local/bin/python3 -m tox -e py -- --cov-report xml:coverage.xml --cov
-    #   after_success:
-    #     - codecov -X gcov -f coverage.xml --name osx_py3.6
-    # ####################################################################################
-    # # Flake8                                                                           #
-    # ####################################################################################
-    # - os: linux
-    #   language: python
-    #   env: TEST=flake8
-    #   python: "3.6"
-    #   install:
-    #     - pip install -U tox
-    #   script:
-    #     - tox -e flake8
-    # ####################################################################################
-    # # Docs and Linkcheck                                                               #
-    # ####################################################################################
-    # - os: linux
-    #   addons:
-    #     apt:
-    #       packages:
-    #         - graphviz
-    #   language: python
-    #   python: "3.6"
-    #   env: TEST=docs_linkcheck
-    #   install:
-    #     - pip install -U tox
-    #   script:
-    #     - tox -e docs,linkcheck
+    ####################################################################################
+    # Linux :: Python :: 2.7                                                           #
+    ####################################################################################
+    - <<: *linux_specs
+      python: "2.7"
+      env: PY=2.7 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0
+    ####################################################################################
+    # Linux :: Python :: 3.6                                                           #
+    ####################################################################################
+    - <<: *linux_specs
+      python: "3.6"
+      env: PY=3.6 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0
+      # Use latest sphinx / breathe (see also: tox.ini)
+    - <<: *linux_specs
+      python: "3.6"
+      env: PY=3.6
+    ####################################################################################
+    # OSX :: Python :: 2.7                                                             #
+    ####################################################################################
+    - os: osx
+      language: generic
+      env: PY=2.7 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0 HOMEBREW_NO_AUTO_UPDATE=1
+      before_install:
+        # Something strange about final step of install gives exit code != 1 but the
+        # installation appears to work?
+        - brew install python@2 || true
+      install:
+        - brew install doxygen
+        - /usr/local/bin/pip install -U tox codecov
+      script:
+        - doxygen --version
+        - /usr/local/bin/python2 --version
+        - /usr/local/bin/python2 -m tox -e py -- --cov-report xml:coverage.xml --cov
+      after_success:
+        - codecov -X gcov -f coverage.xml --name osx_py2.7
+    ####################################################################################
+    # OSX :: Python :: 3.6                                                             #
+    ####################################################################################
+    - os: osx
+      language: generic
+      # Use latest sphinx / breathe (see also: tox.ini)
+      env: PY=3.6 HOMEBREW_NO_AUTO_UPDATE=1
+      before_install:
+        - brew upgrade python || true
+      install:
+        - brew install doxygen
+        - /usr/local/bin/pip3 install -U tox codecov
+      script:
+        - doxygen --version
+        - /usr/local/bin/python3 --version
+        - /usr/local/bin/python3 -m tox -e py -- --cov-report xml:coverage.xml --cov
+      after_success:
+        - codecov -X gcov -f coverage.xml --name osx_py3.6
+    ####################################################################################
+    # Flake8                                                                           #
+    ####################################################################################
+    - os: linux
+      language: python
+      env: TEST=flake8
+      python: "3.6"
+      install:
+        - pip install -U tox
+      script:
+        - tox -e flake8
+    ####################################################################################
+    # Docs and Linkcheck                                                               #
+    ####################################################################################
+    - os: linux
+      addons:
+        apt:
+          packages:
+            - graphviz
+      language: python
+      python: "3.6"
+      env: TEST=docs_linkcheck
+      install:
+        - pip install -U tox
+      script:
+        - tox -e docs,linkcheck
     ####################################################################################
     # testing/projects Code Validation                                                 #
     ####################################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 sudo: false
 
 branches:
-  except:
-    # Ignore fix/* branches since they'll also have a Pull Request build
-    - /^fix.*$/
-    # Ignore feature/* branches since they'll also have a Pull Request build
-    - /^feature.*$/
+  # Other branches receive a Pull Request build.
+  only:
+    - master
 
 # Sphinx version testing done only on Linux (fastest boot / install times).
 # Each test must specify `python: X.Y` and `env: PY=X.Y SPHINX_VERSION=X.Y.Z`.

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ linux_specifications: &linux_specs
     # NOTE: doxygen doesn't seem to work with latest cmake // ninja :/
     - pip install cmake
     - mkdir doxygen && cd doxygen
-    - curl -LO https://github.com/doxygen/doxygen/archive/Release_1_8_14.tar.gz
-    - tar -xf Release_1_8_14.tar.gz
-    - cd doxygen-Release_1_8_14
+    - curl -LO https://github.com/doxygen/doxygen/archive/Release_1_8_15.tar.gz
+    - tar -xf Release_1_8_15.tar.gz
+    - cd doxygen-Release_1_8_15
     - mkdir build && cd build
     - cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=../..
     - make -j

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,18 +127,15 @@ matrix:
     # testing/projects Code Validation                                                 #
     ####################################################################################
     - os: linux
+      dist: xenial
       addons:
         apt:
-          sources:
-            - ubuntu-toolchain-r-test
           packages:
-            - gcc-7
-            - g++-7
-            - gfortran-7
-            - python3.5-setuptools
-            - python3.5
-            - python3.5-dev
-            - python3.5-venv
+            - gcc
+            - g++
+            - gfortran
+            - python3
+            - python3-venv
             - cmake
       language: cpp  # mostly ;)
       env: TEST=testing/projects

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,12 +131,12 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
-            - deadsnakes
           packages:
             - gcc-7
             - g++-7
             - gfortran-7
-            - python3.7
+            - python3
+            - python3-venv
             - cmake
       language: cpp  # mostly ;)
       env: TEST=testing/projects
@@ -146,7 +146,7 @@ matrix:
         - export FC=gfortran-7
       install:
         # I don't want to require sudo because I don't want to wait ;)
-        - python3.7 -m venv venv
+        - python3 -m venv venv
         - source venv/bin/activate
         - pip install -U pip codecov gcovr
         # cpp_long_names test runs code from testing/tests/cpp_long_names.py, so we need

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,6 +135,7 @@ matrix:
             - gcc-7
             - g++-7
             - gfortran-7
+            - python3.5-setuptools
             - python3.5
             - python3.5-dev
             - python3.5-venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,8 +135,8 @@ matrix:
             - gcc-7
             - g++-7
             - gfortran-7
-            - python3
-            - python3-venv
+            - python3.5
+            - python3.5-venv
             - cmake
       language: cpp  # mostly ;)
       env: TEST=testing/projects

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,19 +130,21 @@ matrix:
       dist: xenial
       addons:
         apt:
+          sources:
+            - ubuntu-toolchain-r-test
           packages:
-            - gcc
-            - g++
-            - gfortran
+            - gcc-8
+            - g++-8
+            - gfortran-8
             - python3
             - python3-venv
             - cmake
       language: cpp  # mostly ;)
       env: TEST=testing/projects
       before_install:
-        - export CC=gcc-7
-        - export CXX=g++-7
-        - export FC=gfortran-7
+        - export CC=gcc-8
+        - export CXX=g++-8
+        - export FC=gfortran-8
       install:
         # I don't want to require sudo because I don't want to wait ;)
         - python3 -m venv venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,25 +49,23 @@ matrix:
     ####################################################################################
     - <<: *linux_specs
       python: "2.7"
-      env: PY=2.7 SPHINX_VERSION=1.7.9
-    - <<: *linux_specs
-      python: "2.7"
-      env: PY=2.7 SPHINX_VERSION=1.8.0
+      env: PY=2.7 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0
     ####################################################################################
     # Linux :: Python :: 3.6                                                           #
     ####################################################################################
     - <<: *linux_specs
       python: "3.6"
-      env: PY=3.6 SPHINX_VERSION=1.7.9
+      env: PY=3.6 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0
+      # Use latest sphinx / breathe (see also: tox.ini)
     - <<: *linux_specs
       python: "3.6"
-      env: PY=3.6 SPHINX_VERSION=1.8.0
+      env: PY=3.6
     ####################################################################################
     # OSX :: Python :: 2.7                                                             #
     ####################################################################################
     - os: osx
       language: generic
-      env: PYTHON=2.7
+      env: PY=2.7 SPHINX_VERSION=1.8.5 BREATHE_VERSION=4.12.0
       before_install:
         # Something strange about final step of install gives exit code != 1 but the
         # installation appears to work?
@@ -86,7 +84,8 @@ matrix:
     ####################################################################################
     - os: osx
       language: generic
-      env: PYTHON=3.6
+      # Use latest sphinx / breathe (see also: tox.ini)
+      env: PY=3.6
       before_install:
         - brew upgrade python
       install:
@@ -132,10 +131,12 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+            - deadsnakes
           packages:
             - gcc-7
             - g++-7
             - gfortran-7
+            - python3.7
             - cmake
       language: cpp  # mostly ;)
       env: TEST=testing/projects
@@ -145,8 +146,7 @@ matrix:
         - export FC=gfortran-7
       install:
         # I don't want to require sudo because I don't want to wait ;)
-        - pip install virtualenv
-        - virtualenv venv
+        - python3.7 -m venv venv
         - source venv/bin/activate
         - pip install -U pip codecov gcovr
         # cpp_long_names test runs code from testing/tests/cpp_long_names.py, so we need

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,7 @@ issues_github_path = 'svenevs/exhale'
 
 intersphinx_mapping = {
     'python': ('http://docs.python.org/', None),
-    'sphinx': ('http://sphinx.pocoo.org', None),
+    'sphinx': ('http://www.sphinx-doc.org/en/master', None),
     'pytest': ('https://docs.pytest.org/en/latest/', None),
     # See _intersphinx/README.md
     'bs4':    ('https://www.crummy.com/software/BeautifulSoup/bs4/doc', "_intersphinx/bs4_objects.inv")

--- a/exhale/__init__.py
+++ b/exhale/__init__.py
@@ -8,7 +8,7 @@
 
 from __future__ import unicode_literals
 
-__version__ = "0.2.2"
+__version__ = "0.2.3.dev"
 
 
 def environment_ready(app):

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -16,7 +16,18 @@ __ https://docs.pytest.org/en/latest/example/simple.html#package-directory-level
 from __future__ import unicode_literals
 
 pytest_plugins = [
-    'sphinx.testing.fixtures',
-    'testing.fixtures'
+    "sphinx.testing.fixtures",
+    "testing.fixtures"
 ]
 """Signals to ``pytest`` which plugins are needed for all tests."""
+
+
+def pytest_configure(config):
+    """Register ``@pytest.mark.exhale`` with PyTest."""
+    config.addinivalue_line(
+        "markers", "exhale: internal marker for testing metaclass."
+    )
+    # TODO: upstream this if not fixed already.
+    config.addinivalue_line(
+        "markers", "sphinx: register sphinx test."
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -10,27 +10,32 @@ envlist = py, flake8
 #
 # Problem right now is I need to remember to update this variable...
 [sphinx]
-latest_version = 1.8.3
+latest_version = 2.0.1
+
+[breathe]
+latest_version = 4.13.0.post0
 
 [testenv]
 # Required to be able to send coverage reports from Travis to codecov
 passenv = PYTHONWARNINGS TOXENV CI TRAVIS TRAVIS_*
-usedevelop = True
-# Limitation: requirements.txt has sphinx specification, so doing
-#   sphinx==X.Y.Z
-#   -rrequirements.txt
-#   ...
-# under `deps` breaks.  The workaround here is to install the version specified in the
-# environment variable SPHINX_VERSION, or choose 'latest_version' specified above.
-# Then `pip install -r` in the `commands` section.  Which includes much more output now
-# but I need to test different versions of Sphinx so meh.
+# See TODO below, skipping install since I don't know what is going on...
+# usedevelop = true
+skip_install = true
+# TODO: having issues supporting breathe==4.12.0 and sphinx==1.8.5, on CI it
+# ends up getting breathe==4.13.0.post0 somehow when using -r requirements.txt.
+# Moving requirements here for the time being, will revert when 1.x is in
+# progress / dependencies are changed.
 deps =
     sphinx=={env:SPHINX_VERSION:{[sphinx]latest_version}}
+    breathe=={env:BREATHE_VERSION:{[breathe]latest_version}}
+    bs4
+    lxml
+    six
 commands =
-    pip install -q -r requirements.txt
-    pip install -q -r requirements-dev.txt
+    {envpython} -m pip install -q -r requirements-dev.txt
     pytest . {posargs}
     {envpython} -c 'import sphinx; print("Tested against Sphinx version %s." % sphinx.__version__)'
+    {envpython} -c 'import breathe; print("Tested against Breathe version %s." % breathe.__version__)'
     {envpython} -c 'import sys; print("Tested against Python version %d.%d.%d." % sys.version_info[0:3])'
 
 [testenv:flake8]
@@ -80,5 +85,6 @@ commands =
     rm -rf dist/
     rm -rf exhale.egg-info/
     rm -rf .eggs/
+    rm -rf pip-wheel-metadata/
     find . -name "*.pyc" -exec rm -f \{\} +
     find . -name "__pycache__" -type d -exec rm -rf \{\} +


### PR DESCRIPTION
Breathe 4.13 requires Sphinx 2.0 or later.  Planned patch releases of exhale will be able to support older versions of Sphinx still, but the testing / CI setup needs to change slightly.