### PR TITLE
Allow unabridged API to exclude different kinds.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,16 +38,6 @@ markup syntax / websites.
 
 .. end_exhale_brief_desc
 
-.. begin_tmp_danger_warning
-
-.. note::
-
-   There is a reason why Exhale is development status 2 as far as ``pip`` is concerned.
-   It is functional enough that it should work for your project, but there are a number
-   of features I still intend to implement when there is more time.
-
-.. end_tmp_danger_warning
-
 .. contents:: Contents
    :local:
    :backlinks: none
@@ -120,12 +110,10 @@ __ http://www.sphinx-doc.org/en/stable/extensions.html
 
 .. code-block:: bash
 
+   # NOTE: see version compatibility notes below.
    $ pip install exhale
 
-This will install Exhale, as well as all of its dependencies.  You are of course capable
-of installing Exhale through other means, as it contains a ``setup.py``.  If you choose
-to do this, I assume you know what you are doing (and will provide neither instructions
-nor support for alternative installation strategies).
+This will install Exhale, as well as all of its dependencies.
 
 .. note::
 
@@ -140,6 +128,47 @@ nor support for alternative installation strategies).
    __ http://lxml.de/installation.html
 
 .. end_installation
+
+.. begin_version_compatibility
+
+.. _version_compatibility:
+
+Exhale Version Compatibility with Python, Sphinx, and Breathe
+----------------------------------------------------------------------------------------
+
++----------------+----------------+----------------+-----------------+
+| Exhale Version | Python Version | Sphinx Version | Breathe Version |
++================+================+================+=================+
+| 0.2.1-0.2.3    | 2.7, 3.3+      | >=1.6.1        | "Any"           |
++----------------+----------------+----------------+-----------------+
+| <=0.2.0        | 2.7, 3.3+      | >=1.0          | "Any"           |
++----------------+----------------+----------------+-----------------+
+
+Sphinx 2.0 requires Python 3.5+.  Breathe 4.13.0 drops support for Sphinx<2.0 in better
+support of the Sphinx C++ domain.
+
+Implications:
+
+- **Unless you have a genuine need for Python 2.7**, you will be better served by
+  pinning ``sphinx>=2.0`` and ``breathe>=4.13.0``.  It has many important improvements.
+
+- For Python 3.5+, you should pin your documentation requirements to::
+
+    sphinx>=2.0
+    breathe>=4.13.0
+    exhale
+
+- For Python 2.7, you should pin your documentation requirements to::
+
+    sphinx==1.8.5
+    breathe==4.12.0
+    exhale
+
+**Order matters**, namely that ``sphinx`` and ``breathe`` appear / are installed before
+``exhale``.  Exhale 0.* releases will continue support Python 2.7, but users need to be
+aware of the dependencies between Python, Sphinx, and Breathe versions.
+
+.. end_version_compatibility
 
 Usage
 ----------------------------------------------------------------------------------------
@@ -351,17 +380,6 @@ If you find a problem or think there is something that should change, please sub
 issue (or pull request!) explaining what should change.  I made this because it was
 something I really wanted, and felt the community at large could benefit from as well.
 I put a lot of effort into making it flexible, but it is by no means perfect.
-
-Roadmap
-****************************************************************************************
-
-There are some features I need to / want to implement this summer.  I'm open to
-suggestions / ideas / things you would want to see in this library.  I'll be revamping
-`exhale` this summer when I have a little more time.
-
-The proposed changes are in the project `roadmap <project_roadmap_>`_.
-
-.. _project_roadmap: https://github.com/svenevs/exhale/projects/1
 
 Credit
 ----------------------------------------------------------------------------------------

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,14 @@
+/* Make external links stand out from teletype text. */
+a[class='reference external'] > code > span {
+  color: #2980B9;;
+}
+
+/* Make internal links stand out form teletype text. */
+a[class='reference internal'] > code > span {
+  color: #138a36;
+}
+
+/* Change inline code text color. */
+code > span {
+  color: #343131;
+}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,9 +1,21 @@
 Changelog
 ========================================================================================
 
+*See also:* :ref:`version_compatibility`.
+
 .. contents:: Release Notes
    :local:
    :backlinks: none
+
+v0.2.3
+----------------------------------------------------------------------------------------
+
+- Allow unabridged API to exclude different kinds (:pr:`67`).
+  :data:`~exhale.configs.unabridgedOrphanKinds` allows users to exclude a specific kind
+  from getting dumped in the unabridged API beneath the hierarchies.
+
+  By default, the unabridged API will exclude ``"file"`` and ``"dir"``, given that the
+  file hierarchy already includes these.
 
 v0.2.2
 ----------------------------------------------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,11 +18,11 @@ import exhale
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.0'
+needs_sphinx = '2.0'
 
 # General information about the project.
 project = u'Exhale'
-copyright = u'2018, Stephen McDowell'
+copyright = u'2019, Stephen McDowell'
 author = u'Stephen McDowell'
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -124,12 +124,7 @@ todo_link_only     = True
 
 # -- Options for HTML output ----------------------------------------------
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -158,7 +153,7 @@ html_short_title = 'Exhale'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -225,6 +220,9 @@ htmlhelp_basename = 'ExhaleDoc'
 
 
 def setup(app):
+    # Style overrides.  See _static/custom.css.
+    app.add_css_file("custom.css")
+
     # testproject.py defines these classes (they cannot be defined in conf.py)
     sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
     from testproject import testproject, visit_testproject_node, depart_testproject_node, TestProjectDirective

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,10 +6,6 @@ Exhale
    :end-before:  end_exhale_brief_desc
 
 .. include:: ../README.rst
-   :start-after: begin_tmp_danger_warning
-   :end-before:  end_tmp_danger_warning
-
-.. include:: ../README.rst
    :start-after: begin_exhale_long_desc
    :end-before:  end_exhale_long_desc
 
@@ -27,6 +23,10 @@ See it in Action
 .. include:: ../README.rst
    :start-after: begin_installation
    :end-before:  end_installation
+
+.. include:: ../README.rst
+   :start-after: begin_version_compatibility
+   :end-before: end_version_compatibility
 
 Getting Started
 ----------------------------------------------------------------------------------------

--- a/docs/reference/configs.rst
+++ b/docs/reference/configs.rst
@@ -180,6 +180,11 @@ that you will link to from your documentation is laid out as follows:
       each section be setting the key ``"fullToctreeMaxDepth"`` (e.g. to a smaller
       number such as ``2``).  See :data:`~exhale.configs.fullToctreeMaxDepth`.
 
+   .. tip::
+
+      Use :data:`~exhale.configs.unabridgedOrphanKinds` to exclude entire sections from
+      the full API listing.
+
 8. If provided, the value of the key ``"afterBodySummary"`` will be included at the
    bottom of the document.  See :data:`~exhale.configs.afterBodySummary`.
 
@@ -206,6 +211,8 @@ that you will link to from your documentation is laid out as follows:
 .. autodata:: exhale.configs.fullToctreeMaxDepth
 
 .. autodata:: exhale.configs.listingExclude
+
+.. autodata:: exhale.configs.unabridgedOrphanKinds
 
 Clickable Hierarchies
 ****************************************************************************************

--- a/exhale/configs.py
+++ b/exhale/configs.py
@@ -65,10 +65,6 @@ The |SphinxLoggerAdapter| for communicating with the sphinx build process.
 .. |SphinxLoggerAdapter| replace:: :class:`sphinx:sphinx.util.SphinxLoggerAdapter`
 """
 
-# __all__ = []
-
-__name__ = "configs"
-__docformat__ = "reStructuredText"
 
 ########################################################################################
 ##                                                                                     #

--- a/exhale/deploy.py
+++ b/exhale/deploy.py
@@ -28,9 +28,6 @@ import tempfile
 import textwrap
 from subprocess import PIPE, Popen, STDOUT
 
-__name__      = "deploy"
-__docformat__ = "reStructuredText"
-
 
 def _generate_doxygen(doxygen_input):
     '''

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -3639,7 +3639,13 @@ class ExhaleRoot(object):
                 return k
 
             def __getitem__(self, key):
-                return self.items[self._key(key)]
+                k = self._key(key)
+                if k not in self.items:
+                    sys.stderr.write(utils.critical(
+                        "Unabridged API: unexpected kind '{}' (IGNORED)\n".format(key)
+                    ))
+                    self.items[k] = []
+                return self.items[k]
 
             def __setitem__(self, key, value):
                 self.items[self._key(key)] = value

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -31,8 +31,6 @@ except ImportError:
     from io import StringIO
 
 __all__       = ["ExhaleRoot", "ExhaleNode"]
-__name__      = "graph"
-__docformat__ = "reStructuredText"
 
 
 ########################################################################################

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -963,12 +963,13 @@ class ExhaleRoot(object):
     '''
     def __init__(self):
         # file generation location and root index data
-        self.root_directory        = configs.containmentFolder
-        self.root_file_name        = configs.rootFileName
-        self.full_root_file_path   = os.path.join(self.root_directory, self.root_file_name)
-        self.class_hierarchy_file       = os.path.join(self.root_directory, "class_view_hierarchy.rst")
-        self.file_hierarchy_file   = os.path.join(self.root_directory, "file_view_hierarchy.rst")
-        self.unabridged_api_file   = os.path.join(self.root_directory, "unabridged_api.rst")
+        self.root_directory         = configs.containmentFolder
+        self.root_file_name         = configs.rootFileName
+        self.full_root_file_path    = os.path.join(self.root_directory, self.root_file_name)
+        self.class_hierarchy_file   = os.path.join(self.root_directory, "class_view_hierarchy.rst")
+        self.file_hierarchy_file    = os.path.join(self.root_directory, "file_view_hierarchy.rst")
+        self.unabridged_api_file    = os.path.join(self.root_directory, "unabridged_api.rst")
+        self.unabridged_orphan_file = os.path.join(self.root_directory, "unabridged_orphan.rst")
 
         # whether or not we should generate the raw html tree view
         self.use_tree_view = configs.createTreeView
@@ -3623,73 +3624,95 @@ class ExhaleRoot(object):
         - Typedefs
         - Directories
         - Files
-
-        If you want to change the ordering, just change the order of the calls to
-        :func:`~exhale.graph.ExhaleRoot.enumerateAll` in this method.
         '''
-        ####flake8fail
-        # TODO: I've reverted my decision, the full API should include everything,
-        # including nested types.  the code below invalidates certain portions of the
-        # docs and probably gets rid of a need for the recursive find methods
-        all_namespaces = []
-        all_class_like = []
-        all_enums      = []
-        all_unions     = []
-        all_functions  = []
-        all_variables  = []
-        all_defines    = []
-        all_typedefs   = []
-        all_dirs       = []
-        all_files      = []
+        from collections import MutableMapping
+        class UnabridgedDict(MutableMapping):
+            def __init__(self):
+                self.items = {}
+                for kind in utils.AVAILABLE_KINDS:
+                    self.__setitem__(kind, [])
 
-        for node in self.all_nodes:
-            if node.kind == "namespace":
-                all_namespaces.append(node)
-            elif node.kind == "class" or node.kind == "struct":
-                all_class_like.append(node)
-            elif node.kind == "enum":
-                all_enums.append(node)
-            elif node.kind == "union":
-                all_unions.append(node)
-            elif node.kind == "function":
-                all_functions.append(node)
-            elif node.kind == "variable":
-                all_variables.append(node)
-            elif node.kind == "define":
-                all_defines.append(node)
-            elif node.kind == "typedef":
-                all_typedefs.append(node)
-            elif node.kind == "dir":
-                all_dirs.append(node)
-            elif node.kind == "file":
-                all_files.append(node)
+            def _key(self, k):
+                # Just need to fold class and struct to same bucket.
+                if k == "struct":
+                    return "class"
+                return k
+
+            def __getitem__(self, key):
+                return self.items[self._key(key)]
+
+            def __setitem__(self, key, value):
+                self.items[self._key(key)] = value
+
+            def __delitem__(self, key):
+                del self.items[self._key(key)]
+
+            def __iter__(self):
+                return iter(self.items)
+
+            def __len__(self):
+                return len(self.items)
 
         try:
-            with codecs.open(self.unabridged_api_file, "w", "utf-8") as full_api_file:
-                # write the header
-                full_api_file.write(textwrap.dedent('''
+            # Gather all nodes in an easy to index dictionary mapping node.kind to the
+            # node itself.  "class" and "struct" are stored together.
+            unabridged_specs = UnabridgedDict()
+            for node in self.all_nodes:
+                unabridged_specs[node.kind].append(node)
+
+            # Create the buffers to write to and dump the page headings.
+            unabridged_api = StringIO()
+            orphan_api = StringIO()
+            for page, is_orphan in [(unabridged_api, False), (orphan_api, True)]:
+                if is_orphan:
+                    page.write(":orphan:\n\n")
+                page.write(textwrap.dedent('''
                     {heading}
                     {heading_mark}
-
                 '''.format(
                     heading=configs.fullApiSubSectionTitle,
                     heading_mark=utils.heading_mark(
                         configs.fullApiSubSectionTitle,
-                        configs.SUB_SECTION_HEADING_CHAR
+                        configs.SECTION_HEADING_CHAR if is_orphan
+                        else configs.SUB_SECTION_HEADING_CHAR
                     )
                 )))
 
-                # write everything to file: reorder these lines for different outcomes
-                self.enumerateAll(         "Namespaces", all_namespaces, full_api_file)
-                self.enumerateAll("Classes and Structs", all_class_like, full_api_file)
-                self.enumerateAll(              "Enums",      all_enums, full_api_file)
-                self.enumerateAll(             "Unions",     all_unions, full_api_file)
-                self.enumerateAll(          "Functions",  all_functions, full_api_file)
-                self.enumerateAll(          "Variables",  all_variables, full_api_file)
-                self.enumerateAll(            "Defines",    all_defines, full_api_file)
-                self.enumerateAll(           "Typedefs",   all_typedefs, full_api_file)
-                self.enumerateAll(        "Directories",       all_dirs, full_api_file)
-                self.enumerateAll(              "Files",      all_files, full_api_file)
+            dump_order = [
+                ("Namespaces", "namespace"),
+                ("Classes and Structs", "class"),  # NOTE: class/struct stored together!
+                ("Enums", "enum"),
+                ("Unions", "union"),
+                ("Functions", "function"),
+                ("Variables", "variable"),
+                ("Defines", "define"),
+                ("Typedefs", "typedef"),
+                ("Directories", "dir"),
+                ("Files", "file")
+            ]
+            for title, kind in dump_order:
+                node_list = unabridged_specs[kind]
+                # Write to orphan_api if this kind is to be ignored, or the kind is
+                # "class" and "struct" was ignored (stored together).
+                if kind in configs.unabridgedOrphanKinds or \
+                        (kind == "class" and "struct" in configs.unabridgedOrphanKinds) or \
+                        (kind == "struct" and "class" in configs.unabridgedOrphanKinds):
+                    dest = orphan_api
+                else:
+                    dest = unabridged_api
+                self.enumerateAll(title, node_list, dest)
+
+            # Write out the unabridged api file (gets included to root).
+            with codecs.open(self.unabridged_api_file, "w", "utf-8") as full_api_file:
+                full_api_file.write(unabridged_api.getvalue())
+
+            # If the orphan file has any .. toctree:: in there, then we want to make
+            # sure to write it.  For example, if files and directories are dumped here,
+            # we want Sphinx to be convinced that they show up in a toctree somewhere.
+            orphan_api_value = orphan_api.getvalue()
+            if "toctree" in orphan_api_value:
+                with codecs.open(self.unabridged_orphan_file, "w", "utf-8") as orphan_file:
+                    orphan_file.write(orphan_api_value)
         except:
             utils.fancyError("Error writing the unabridged API.")
 

--- a/exhale/parse.py
+++ b/exhale/parse.py
@@ -15,8 +15,6 @@ import textwrap
 from bs4 import BeautifulSoup
 
 __all__       = ["walk", "convertDescriptionToRST", "getBriefAndDetailedRST"]
-__name__      = "utils"
-__docformat__ = "reStructuredText"
 
 
 def walk(textRoot, currentTag, level, prefix=None, postfix=None, unwrapUntilPara=False):

--- a/exhale/utils.py
+++ b/exhale/utils.py
@@ -28,9 +28,6 @@ try:
 except:
     __USE_PYGMENTS = False
 
-__name__      = "utils"
-__docformat__ = "reStructuredText"
-
 
 def heading_mark(title, char):
     '''

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -31,3 +31,10 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "sphinx: register sphinx test."
     )
+
+
+def pytest_runtest_setup(item):
+    """.. todo:: stop reloading configs module in 1.x."""
+    from six.moves import reload_module
+    from exhale import configs
+    reload_module(configs)

--- a/testing/tests/cpp_pimpl.py
+++ b/testing/tests/cpp_pimpl.py
@@ -401,25 +401,6 @@ class CPPPimpl(ExhaleTestCase):
             self.contents_for_node(jupiter_hpp), required=self.jupiter_hpp_link_names(), forbidden=None
         )
 
-    def validate_full_api_listing(self):
-        """
-        Validate that every node shows up in the full api listing.
-
-        .. todo:: Maybe this should be a default check instead?
-        """
-        exhale_root = get_exhale_root(self)
-        with open(exhale_root.unabridged_api_file) as api_root:
-            api_root_contents = api_root.read()
-
-        for node in exhale_root.all_nodes:
-            self.assertTrue(
-                node.file_name in api_root_contents,
-                "{file_name} not included in {unabridged_api}!".format(
-                    file_name=node.file_name,
-                    unabridged_api=exhale_root.unabridged_api_file
-                )
-            )
-
     def test_hierarchies(self):
         """Verify the class and file hierarchies."""
         compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict))
@@ -433,7 +414,7 @@ class CPPPimpl(ExhaleTestCase):
         self.validate_class_hierarchy(TestedExclusionTypes.NoExclusions)
         self.validate_namespace_listings(TestedExclusionTypes.NoExclusions)
         self.validate_file_listings()
-        self.validate_full_api_listing()
+        self.checkAllFilesIncluded()
 
     @confoverrides(exhale_args={"listingExclude": [r".*Impl$"]})
     def test_impl_exclude(self):
@@ -441,7 +422,7 @@ class CPPPimpl(ExhaleTestCase):
         self.validate_class_hierarchy(TestedExclusionTypes.AllImpl)
         self.validate_namespace_listings(TestedExclusionTypes.AllImpl)
         self.validate_file_listings()
-        self.validate_full_api_listing()
+        self.checkAllFilesIncluded()
 
     @confoverrides(exhale_args={"listingExclude": [(r".*impl$", re.IGNORECASE)]})
     def test_impl_exclude_ignorecase(self):
@@ -451,7 +432,7 @@ class CPPPimpl(ExhaleTestCase):
         self.validate_class_hierarchy(TestedExclusionTypes.AllImpl)
         self.validate_namespace_listings(TestedExclusionTypes.AllImpl)
         self.validate_file_listings()
-        self.validate_full_api_listing()
+        self.checkAllFilesIncluded()
 
     @confoverrides(exhale_args={"listingExclude": [r".*detail::.*Impl$"]})
     def test_detail_impl_exclude(self):
@@ -461,7 +442,7 @@ class CPPPimpl(ExhaleTestCase):
         self.validate_class_hierarchy(TestedExclusionTypes.DetailImpl)
         self.validate_namespace_listings(TestedExclusionTypes.DetailImpl)
         self.validate_file_listings()
-        self.validate_full_api_listing()
+        self.checkAllFilesIncluded()
 
     @confoverrides(exhale_args={"listingExclude": [(r".*detail::.*impl$", re.IGNORECASE)]})
     def test_detail_impl_exclude_ignorecase(self):
@@ -473,4 +454,4 @@ class CPPPimpl(ExhaleTestCase):
         self.validate_class_hierarchy(TestedExclusionTypes.DetailImpl)
         self.validate_namespace_listings(TestedExclusionTypes.DetailImpl)
         self.validate_file_listings()
-        self.validate_full_api_listing()
+        self.checkAllFilesIncluded()


### PR DESCRIPTION
Fixes #64.

- Default to trimming `dir` and `file`.
- Utilize `:orphan:` page attribute (to be continued?).