### PR TITLE
fix function overloads

### DIFF
--- a/exhale/utils.py
+++ b/exhale/utils.py
@@ -276,8 +276,8 @@ def sanitize(name):
         "< ", "<"
     ).replace(
         " >", ">"
-    ).replace(
-        " &", "&"
+    # ).replace(
+    #     " &", "&"
     ).replace(
         "& ", "&"
     )

--- a/testing/hierarchies.py
+++ b/testing/hierarchies.py
@@ -952,8 +952,11 @@ def _compare_children(hierarchy_type, test, test_child, exhale_child):
                 if candidate.kind == test_grand_child.kind and candidate.name == test_grand_child.name:
                     exhale_grand_child = candidate
         if not exhale_grand_child:
+            import pdb
+            pdb.set_trace()
             raise RuntimeError("Matching child for [{0}] '{1}' not found!".format(
-                test_grand_child.kind, test_grand_child.name
+                test_grand_child.kind,
+                test_grand_child.name if test_grand_child.kind != "function" else test_grand_child.full_signature()
             ))
         _compare_children(hierarchy_type, test, test_grand_child, exhale_grand_child)
 

--- a/testing/projects/cpp_func_overloads/include/overload/overload.hpp
+++ b/testing/projects/cpp_func_overloads/include/overload/overload.hpp
@@ -82,6 +82,7 @@ namespace overload {
         return t;
     }
 
+    /*
     /// Returns parameter ``t`` converted to a ``T`` (enabled when ``std::is_convertible`` is ``true``).
     template <class C, typename T>
     typename std::enable_if<
@@ -97,6 +98,7 @@ namespace overload {
     >::type blargh(typename C::type t) {
         return T();
     }
+    */
 }// namespace overload
 
 /// A free hanging function shows up in the file XML page, the others are in the namespace XML.

--- a/testing/projects/cpp_func_overloads/include/tt/tt.hpp
+++ b/testing/projects/cpp_func_overloads/include/tt/tt.hpp
@@ -1,0 +1,116 @@
+/***************************************************************************************
+ * This file is dedicated to the public domain.  If your jurisdiction requires a       *
+ * specific license:                                                                   *
+ *                                                                                     *
+ * Copyright (c) Stephen McDowell, 2017-2019                                           *
+ * License:      CC0 1.0 Universal                                                     *
+ * License Text: https://creativecommons.org/publicdomain/zero/1.0/legalcode           *
+ **************************************************************************************/
+/**
+ * \file
+ *
+ * \brief Overloaded function tests with operators, see issue #90.
+ */
+#pragma once
+
+#include <iostream>
+
+namespace tt {
+
+    struct AudioDevice_state { };///< State of audio device.
+    struct FontWeight { };///< Weight of font.
+    enum class KeyboardModifiers : uint8_t { };///< Bitmasking modifiers to control keyboard.
+    struct KeyboardVirtualKey { };///< Keyboard magic.
+    struct TextDecoration { };///< For when bold isn't bold enough.
+    struct ThemeMode { };///< Prefer dark themes.
+    using cell_address = uint32_t;///< Cell indexing stuffs.
+    using command = uint16_t;///< Command sequence `0x1111 ` is reserved.
+    struct URL { };///< httpseverywhere
+    using datum_type_t = uint8_t;///< Oh no our datum is so small :(
+    using glob_token_t = int32_t;///< It is ok to mix with datum ;)
+    using glob_token_type_t = int16_t;///< This doesn't get used often.
+    using source_code_ptr = void *;///< Hehe.
+    using tokenizer_name_t = double;///< Waste of precision.
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, AudioDevice_state const &rhs) {
+        return lhs << "AudioDevice_state const &rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, FontWeight const &rhs) {
+        return lhs << "FontWeight const &rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, KeyboardModifiers const &rhs) {
+        return lhs << "KeyboardModifiers const &rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, KeyboardVirtualKey const &rhs) {
+        return lhs << "KeyboardVirtualKey const &rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, TextDecoration const &rhs) {
+        return lhs << "TextDecoration const &rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, ThemeMode rhs) {
+        return lhs << "ThemeMode rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, cell_address const &rhs) {
+        return lhs << "cell_address const &rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, command const &rhs) {
+        return lhs << "command const &rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, const URL &rhs) {
+        return lhs << "const URL &rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, datum_type_t rhs) {
+        return lhs << "datum_type_t rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, glob_token_t const &rhs) {
+        return lhs << "glob_token_t const &rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, glob_token_type_t const &rhs) {
+        return lhs << "glob_token_type_t const &rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, source_code_ptr const &rhs) {
+        return lhs << "source_code_ptr const &rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+    /// \brief Adds `typeid(rhs).name()` to `lhs` with arbitrary formatting.
+    inline std::ostream &operator<<(std::ostream &lhs, tokenizer_name_t rhs) {
+        return lhs << "tokenizer_name_t rhs) {{{ " << typeid(rhs).name() << "}}}";
+    }
+
+/* TODO (untested TBD not now):
+ * Template overloads may be more of a problem.  See also:
+ * https://github.com/svenevs/exhale/blob/58c6c771fe021d7487644a30c2575b3fcf1ae94b/exhale/graph.py#L2372
+ *
+ * :(
+ *
+    template<typename T, int M> std::ostream &operator<<(std::ostream &lhs, fixed<T, M> const &rhs)
+    template<typename T, int N> std::ostream &operator<<(std::ostream &os, results<T, N> const &r)
+    template<typename Tag, typename ...InfoTags> std::ostream &operator<<(std::ostream &lhs, trace_data<Tag, InfoTags...> const &rhs)
+ */
+
+}// namespace tt

--- a/testing/tests/cpp_func_overloads.py
+++ b/testing/tests/cpp_func_overloads.py
@@ -14,7 +14,7 @@ from __future__ import unicode_literals
 from testing.base import ExhaleTestCase
 from testing.decorators import no_cleanup
 from testing.hierarchies import \
-    compare_file_hierarchy, directory, file, file_hierarchy, function, namespace, parameters
+    compare_file_hierarchy, clike, directory, enum, file, file_hierarchy, function, namespace, parameters, typedef
 
 
 class CPPFuncOverloads(ExhaleTestCase):
@@ -63,17 +63,79 @@ class CPPFuncOverloads(ExhaleTestCase):
                         ),
                         # templates
                         function("C::type", "blargh", template=["class C"]): parameters("typename C::type"),
-                        # SFINAE is really pretty yeah?
-                        function(
-                            "std::enable_if<std::is_convertible<typename C::type, T>::value, T>::type",
-                            "blargh",
-                            template=["class C", "typename T"]
-                        ): parameters("typename C::type"),
-                        function(
-                            "std::enable_if<!std::is_convertible<typename C::type, T>::value, T>::type",
-                            "blargh",
-                            template=["class C", "typename T"]
-                        ): parameters("typename C::type")
+                        # # SFINAE is really pretty yeah?
+                        # function(
+                        #     "std::enable_if<std::is_convertible<typename C::type, T>::value, T>::type",
+                        #     "blargh",
+                        #     template=["class C", "typename T"]
+                        # ): parameters("typename C::type"),
+                        # function(
+                        #     "std::enable_if<!std::is_convertible<typename C::type, T>::value, T>::type",
+                        #     "blargh",
+                        #     template=["class C", "typename T"]
+                        # ): parameters("typename C::type")
+                    }
+                }
+            },
+            directory("tt"): {
+                file("tt.hpp"): {
+                    namespace("tt"): {
+                        clike("struct", "AudioDevice_state"): {},
+                        clike("struct", "FontWeight"): {},
+                        enum("KeyboardModifiers"): {},
+                        clike("struct", "KeyboardVirtualKey"): {},
+                        clike("struct", "TextDecoration"): {},
+                        clike("struct", "ThemeMode"): {},
+                        typedef("cell_address", "uint32_t"): {},
+                        typedef("command", "uint16_t"): {},
+                        clike("struct", "URL"): {},
+                        typedef("datum_type_t", "uint8_t"): {},
+                        typedef("glob_token_t", "int32_t"): {},
+                        typedef("glob_token_type_t", "int16_t"): {},
+                        typedef("source_code_ptr", "void *"): {},
+                        typedef("tokenizer_name_t", "double"): {},
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "AudioDevice_state const &rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "FontWeight const &rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "KeyboardModifiers const &rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "KeyboardVirtualKey const &rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "TextDecoration const &rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "ThemeMode rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "cell_address const &rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "command const &rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "const URL &rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "datum_type_t rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "glob_token_t const &rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "glob_token_type_t const &rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "source_code_ptr const &rhs"
+                        ),
+                        function("std::ostream&", "operator<<"): parameters(
+                            "std::ostream &lhs", "tokenizer_name_t rhs"
+                        )
                     }
                 }
             }

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ skip_install = true
 # Moving requirements here for the time being, will revert when 1.x is in
 # progress / dependencies are changed.
 deps =
-    sphinx=={env:SPHINX_VERSION:{[sphinx]latest_version}}
-    breathe=={env:BREATHE_VERSION:{[breathe]latest_version}}
+    sphinx
+    breathe
     bs4
     lxml
     six


### PR DESCRIPTION
Fixes #90.

- [X] Add representative-enough-ish cpp code in #90.
- [ ] Determine newer breathe reqs (when did 3.x become required etc) and test across more versions.  I distinctly recall excluding `declname` for a reason?
- [ ] Fix cpp func overload tests by adding variable names in (update all other `function` calls too most likely).

To test this checkout the `fix/func_overloads` branch and run `tox -e py -- -k func_overloads` and if those pass now `tox -e py`.