### PR TITLE
Skip link generation when target node is missing

### DIFF
--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -398,6 +398,8 @@ class ExhaleNode(object):
 
             # Create the link, if possible
             # TODO: how to do intersphinx links here?
+            # NOTE: refid is *NOT* guaranteed to be in nodeByRefid
+            #       https://github.com/svenevs/exhale/pull/103
             if refid and refid in nodeByRefid:
                 # TODO: why are these links not working????????????????????????????????
                 ###########flake8breaks :/ :/ :/ :/ :/ :/ :/ :/ :/ :/ :/ :/ :/ :/ :/ :/

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -398,7 +398,7 @@ class ExhaleNode(object):
 
             # Create the link, if possible
             # TODO: how to do intersphinx links here?
-            if refid:
+            if refid and refid in nodeByRefid:
                 # TODO: why are these links not working????????????????????????????????
                 ###########flake8breaks :/ :/ :/ :/ :/ :/ :/ :/ :/ :/ :/ :/ :/ :/ :/ :/
                 # if please_close:


### PR DESCRIPTION
The target node for a link can be missing e.g. when it is explicitly
excluded from the Doxygen documentation and thus doesn't appear
in the XML output. This is a quick workaround that skips the link
generation instead of aborting.

This also works around #63.