### PR TITLE
Add support for Doxygen pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,8 +256,9 @@ This structure is not required, but you'll need to change values accordingly.
        # These arguments are required
        "containmentFolder":     "./api",
        "rootFileName":          "library_root.rst",
-       "rootFileTitle":         "Library API",
        "doxygenStripFromPath":  "..",
+       # Heavily encouraged optional argument (see docs)
+       "rootFileTitle":         "Library API",
        # Suggested optional arguments
        "createTreeView":        True,
        # TIP: if using the sphinx-bootstrap-theme, you need

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,12 @@ v0.2.4
 - Use the correct PyPI name ``beautifulsoup4`` rather than ``bs4`` (:pr:`120`).
 - Fix deprecated ``MutableMapping`` import for python 3.10 support (:pr:`124`).
 - Enable parallel builds (use the right ``setup`` function...) (:pr:`126`).
+- Add support for ``.. doxygenpage::`` (:pr:`114`).  **Huge** thanks to:
+    - `@hidmic <https://github.com/hidmic>`_ for the initial implementiation, and
+    - `@2bndy5 <https://github.com/2bndy5>`_ and
+      `@clalancette <https://github.com/clalancette>`_ for their efforts in improving
+      the doxygen-breathe-exhale-sphinx ecosystem (and consequently, encouraging me to
+      resume work on this project).
 
 v0.2.3
 ----------------------------------------------------------------------------------------

--- a/docs/reference/configs.rst
+++ b/docs/reference/configs.rst
@@ -91,12 +91,16 @@ Users must provide the following values to ``exhale_args`` in their ``conf.py``.
 
 .. autodata:: exhale.configs.rootFileName
 
-.. autodata:: exhale.configs.rootFileTitle
-
 .. autodata:: exhale.configs.doxygenStripFromPath
 
 Optional Configuration Arguments
 ----------------------------------------------------------------------------------------
+
+Heavily Encouraged Optional Configuration
+****************************************************************************************
+
+.. autodata:: exhale.configs.rootFileTitle
+
 
 Build Process Logging, Colors, and Debugging
 ****************************************************************************************
@@ -135,8 +139,9 @@ that you will link to from your documentation is laid out as follows:
     | **9**      | {{ afterBodySummary }}                             | Section 8      |
     +------------+----------------------------------------------------+----------------+
 
-1. The title of the document will be the *required* key to ``"rootFileTitle"`` given to
-   ``exhale_args`` in ``conf.py``.  See :data:`~exhale.configs.rootFileTitle`.
+1. The title of the document will be the key to ``"rootFileTitle"`` given to
+   ``exhale_args`` in ``conf.py`` **unless** the ``\mainpage`` command is being used
+   on the doxygen side.  See :data:`~exhale.configs.rootFileTitle`.
 
 2. If provided, the value of the key ``"afterTitleDescription"`` given to
    ``exhale_args`` will be included.  See :data:`~exhale.configs.afterTitleDescription`.
@@ -153,6 +158,10 @@ that you will link to from your documentation is laid out as follows:
 
       This is performed by an ``.. include::`` directive.  The file for this section
       is ``"{containmentFolder}/page_view_hierarchy.rst"``.
+
+   .. tip::
+
+      Please also see the documentation for :data:`~exhale.configs.rootFileTitle`.
 
 4. Next, the Class Hierarchy is included.  If no class-like compounds are documented in
    the project (e.g., only free-standing functions), this section will not be included.

--- a/docs/reference/configs.rst
+++ b/docs/reference/configs.rst
@@ -120,17 +120,19 @@ that you will link to from your documentation is laid out as follows:
     +============+====================================================+================+
     | **2**      | {{ afterTitleDescription }}                        | Section 1      |
     +------------+----------------------------------------------------+----------------+
-    | **3**      | Class Hierarchy                                    | Section 2      |
+    | **3**      | Page Hierarchy                                     | Section 2      |
     +------------+----------------------------------------------------+----------------+
-    | **4**      | File Hierarchy                                     | Section 3      |
+    | **4**      | Class Hierarchy                                    | Section 3      |
     +------------+----------------------------------------------------+----------------+
-    | **5**      | {{ afterHierarchyDescription }}                    | Section 4      |
+    | **5**      | File Hierarchy                                     | Section 4      |
     +------------+----------------------------------------------------+----------------+
-    | **6**      | {{ fullApiSubSectionTitle }}                       | Section 5      |
+    | **6**      | {{ afterHierarchyDescription }}                    | Section 5      |
     +------------+----------------------------------------------------+----------------+
-    | **7**      | Unabridged API                                     | Section 6      |
+    | **7**      | {{ fullApiSubSectionTitle }}                       | Section 6      |
     +------------+----------------------------------------------------+----------------+
-    | **8**      | {{ afterBodySummary }}                             | Section 7      |
+    | **8**      | Unabridged API                                     | Section 7      |
+    +------------+----------------------------------------------------+----------------+
+    | **9**      | {{ afterBodySummary }}                             | Section 8      |
     +------------+----------------------------------------------------+----------------+
 
 1. The title of the document will be the *required* key to ``"rootFileTitle"`` given to
@@ -139,15 +141,30 @@ that you will link to from your documentation is laid out as follows:
 2. If provided, the value of the key ``"afterTitleDescription"`` given to
    ``exhale_args`` will be included.  See :data:`~exhale.configs.afterTitleDescription`.
 
-3. The Class Hierarchy will be included next.  By default this is a bulleted list; see
-   the :ref:`usage_creating_the_treeview` section.
+3. The Page Hierarchy will be included.  This section is only included if the project is
+   using the ``\page`` / ``\subpage`` doxygen commands in its documentation.  If those
+   commands are not present, this section is not included.  By default this is a
+   bulleted list; see the :ref:`usage_creating_the_treeview` section. The default title
+   for this section is ``"Page Hierarchy"``, but can be changed using the key
+   ``"pageHierarchySubSectionTitle"`` in ``exhale_args``.  See
+   :data:`~exhale.configs.pageHierarchySubSectionTitle`.
+
+   .. note::
+
+      This is performed by an ``.. include::`` directive.  The file for this section
+      is ``"{containmentFolder}/page_view_hierarchy.rst"``.
+
+4. Next, the Class Hierarchy is included.  If no class-like compounds are documented in
+   the project (e.g., only free-standing functions), this section will not be included.
+   By default this is a bulleted list; see the :ref:`usage_creating_the_treeview`
+   section.
 
    .. note::
 
       This is performed by an ``.. include::`` directive.  The file for this section
       is ``"{containmentFolder}/class_view_hierarchy.rst"``.
 
-4. Next, the File Hierarchy is included.  By default this is a bulleted list; see the
+5. Next, the File Hierarchy is included.  By default this is a bulleted list; see the
    :ref:`usage_creating_the_treeview` section.
 
    .. note::
@@ -155,16 +172,16 @@ that you will link to from your documentation is laid out as follows:
       This is performed by an ``.. include::`` directive.  The file for this section
       is ``"{containmentFolder}/file_view_hierarchy.rst"``.
 
-5. If provided, the value of the key ``"afterHierarchyDescription"`` given to
+6. If provided, the value of the key ``"afterHierarchyDescription"`` given to
    ``exhale_args`` will be included.  See
    :data:`~exhale.configs.afterHierarchyDescription`.
 
-6. After the Class and File Hierarchies, the unabridged API index is generated.  The
+7. After the Class and File Hierarchies, the unabridged API index is generated.  The
    default title for this section is ``"Full API"``, but can be changed using the key
    ``"fullApiSubSectionTitle"`` in ``exhale_args``.  See
    :data:`~exhale.configs.fullApiSubSectionTitle`.
 
-7. After the title or default value for (6), the full API is included.  This includes
+8. After the title or default value for (6), the full API is included.  This includes
    links to things such as defines, functions, typedefs, etc. that are not included in
    the hierarchies.
 
@@ -185,12 +202,12 @@ that you will link to from your documentation is laid out as follows:
       Use :data:`~exhale.configs.unabridgedOrphanKinds` to exclude entire sections from
       the full API listing.
 
-8. If provided, the value of the key ``"afterBodySummary"`` will be included at the
+9. If provided, the value of the key ``"afterBodySummary"`` will be included at the
    bottom of the document.  See :data:`~exhale.configs.afterBodySummary`.
 
 .. tip::
 
-   Where numbers (3), (4), and (7) are concerned, you should be able to happily ignore
+   Where numbers (4), (5), and (8) are concerned, you should be able to happily ignore
    that an ``.. include::`` is being performed.  The URL for the page is strictly
    determined by what you specified with the *required* arguments
    ``"containmentFolder"`` and ``"rootFileName"``.  However, if things are not working
@@ -201,6 +218,8 @@ that you will link to from your documentation is laid out as follows:
 .. end_root_api_document_layout
 
 .. autodata:: exhale.configs.afterTitleDescription
+
+.. autodata:: exhale.configs.pageHierarchySubSectionTitle
 
 .. autodata:: exhale.configs.afterHierarchyDescription
 
@@ -294,10 +313,13 @@ Neither library should produce any legal gray areas for you, but I'm not a lawye
 
 .. autodata:: exhale.configs._file_hierarchy_id
 
+.. autodata:: exhale.configs._page_hierarchy_id
+
 .. autodata:: exhale.configs._bstrap_class_hierarchy_fn_data_name
 
 .. autodata:: exhale.configs._bstrap_file_hierarchy_fn_data_name
 
+.. autodata:: exhale.configs._bstrap_page_hierarchy_fn_data_name
 
 Page Level Customization
 ****************************************************************************************

--- a/exhale/configs.py
+++ b/exhale/configs.py
@@ -137,22 +137,6 @@ rootFileName = None
        </div>
 '''
 
-rootFileTitle = None
-'''
-**Optional**
-    The title to be written at the top of ``rootFileName``, which will appear in your
-    file including it in the ``toctree`` directive.
-
-**Value in** ``exhale_args`` (str)
-    The value of the key ``"rootFileTitle"`` should be a string that has the title of
-    the main library root document folder Exhale will be generating. For example, if
-    you are including the Exhale generated library root file in your ``index.rst``
-    top-level ``toctree`` directive, the title you supply here will show up on both
-    your main page, as well as in the navigation menus.
-
-    An example value could be ``"Library API"``.
-'''
-
 doxygenStripFromPath = None
 '''
 **Required**
@@ -213,6 +197,40 @@ doxygenStripFromPath = None
 ##                                                                                     #
 ## Additional configurations available to further customize the output of exhale.      #
 ##                                                                                     #
+########################################################################################
+# Heavily Encouraged Optional Configuration                                            #
+########################################################################################
+rootFileTitle = None
+r'''
+**Optional**
+    The title to be written at the top of ``rootFileName``, which will appear in your
+    file including it in the ``toctree`` directive.
+
+**Value in** ``exhale_args`` (str)
+    The value of the key ``"rootFileTitle"`` should be a string that has the title of
+    the main library root document folder Exhale will be generating. For example, if
+    you are including the Exhale generated library root file in your ``index.rst``
+    top-level ``toctree`` directive, the title you supply here will show up on both
+    your main page, as well as in the navigation menus.
+
+    An example value could be ``"Library API"``.
+
+.. danger::
+
+    If you are **not** using doxygen pages (``\mainpage``, ``\page``, and/or
+    ``\subpage`` commands), then you need to include this argument!  Exhale does not
+    have the ability to detect whether or not your project needs this.
+
+    **If** ``\mainpage`` **is used:**
+        The title is set to the ``\mainpage`` title unconditionally.
+    **Otherwise:**
+        The title is set to ``"rootFileTitle"`` (this config).
+
+    Since :data:`~exhale.configs.rootFileName` is ultimately going to be included in a
+    ``.. toctree::`` directive, this document needs a title in some way.  Projects
+    utilizing the ``\mainpage`` command should not be required to duplicate this title,
+    projects **not** using this command **need to supply a title**.
+'''
 ########################################################################################
 # Build Process Logging, Colors, and Debugging                                         #
 ########################################################################################

--- a/exhale/configs.py
+++ b/exhale/configs.py
@@ -139,18 +139,16 @@ rootFileName = None
 
 rootFileTitle = None
 '''
-**Required**
+**Optional**
     The title to be written at the top of ``rootFileName``, which will appear in your
     file including it in the ``toctree`` directive.
 
 **Value in** ``exhale_args`` (str)
     The value of the key ``"rootFileTitle"`` should be a string that has the title of
-    the main library root document folder Exhale will be generating.  The user is
-    required to supply this value because its value directly affects the overall
-    presentation of your documentation.  For example, if you are including the Exhale
-    generated library root file in your ``index.rst`` top-level ``toctree`` directive,
-    the title you supply here will show up on both your main page, as well as in the
-    navigation menus.
+    the main library root document folder Exhale will be generating. For example, if
+    you are including the Exhale generated library root file in your ``index.rst``
+    top-level ``toctree`` directive, the title you supply here will show up on both
+    your main page, as well as in the navigation menus.
 
     An example value could be ``"Library API"``.
 '''
@@ -319,6 +317,16 @@ afterTitleDescription = None
        }
 '''
 
+pageHierarchySubSectionTitle = "Page Hierarchy"
+'''
+**Optional**
+    The title for the subsection that comes before the Page hierarchy.
+
+**Value in** ``exhale_args`` (str)
+    The default value is simply ``"Page Hierarchy"``.  Change this to be something else if you
+    so desire.
+'''
+
 afterHierarchyDescription = None
 '''
 **Optional**
@@ -433,7 +441,7 @@ listingExclude = []
 # TODO: moves into config object
 _compiled_listing_exclude = []
 
-unabridgedOrphanKinds = {"dir", "file"}
+unabridgedOrphanKinds = {"dir", "file", "page"}
 """
 **Optional**
     The list of node kinds to **exclude** from the unabridged API listing beneath the
@@ -441,10 +449,11 @@ unabridgedOrphanKinds = {"dir", "file"}
 
 **Value in** ``exhale_args`` (list or set of strings)
     The list of kinds (see :data:`~exhale.utils.AVAILABLE_KINDS`) that will **not** be
-    included in the unabridged API listing.  The default is to exclude directories and
-    files (which are already in the file hierarchy).  Note that if this variable is
-    provided, it will overwrite the default  ``{"dir", "file"}``, meaning if you want
-    to exclude something in addition you need to include ``"dir"`` and ``"file"``:
+    included in the unabridged API listing.  The default is to exclude pages (which are
+    already in the page hierarhcy), directories and files (which are already in the file
+    hierarchy).  Note that if this variable is provided, it will overwrite the default
+    ``{"dir", "file", "page"}``, meaning if you want to exclude something in addition
+    you need to include ``"page"``,  ``"dir"``, and ``"file"``:
 
     .. code-block:: py
 
@@ -452,8 +461,8 @@ unabridgedOrphanKinds = {"dir", "file"}
         exhale_args = {
             # Case 1: _only_ exclude union
             "unabridgedOrphanKinds": {"union"}
-            # Case 2: exclude union in addition to dir / file.
-            "unabridgedOrphanKinds": {"dir", "file", "union"}
+            # Case 2: exclude union in addition to dir / file / page.
+            "unabridgedOrphanKinds": {"dir", "file", "page", union"}
         }
 
     .. tip::
@@ -716,6 +725,17 @@ The ``id`` attribute of the HTML element associated with the **Class** Hierarchy
    anchor point for the ``bootstrap-treeview`` library.
 '''
 
+_page_hierarchy_id = "page-treeView"
+'''
+The ``id`` attribute of the HTML element associated with the **Page** Hierarchy when
+:data:`~exhale.configs.createTreeView` is ``True``.
+
+1. When :data:`~exhale.configs.treeViewIsBootstrap` is ``False``, this ``id`` is attached
+   to the outer-most ``ul``.
+2. For bootstrap, an empty ``div`` is inserted with this ``id``, which will be the
+   anchor point for the ``bootstrap-treeview`` library.
+'''
+
 _bstrap_class_hierarchy_fn_data_name = "getClassHierarchyTree"
 '''
 The name of the JavaScript function that returns the ``json`` data associated with the
@@ -727,6 +747,13 @@ _bstrap_file_hierarchy_fn_data_name = "getFileHierarchyTree"
 '''
 The name of the JavaScript function that returns the ``json`` data associated with the
 **File** Hierarchy when :data:`~exhale.configs.createTreeView` is ``True`` **and**
+:data:`~exhale.configs.treeViewIsBootstrap` is ``True``.
+'''
+
+_bstrap_page_hierarchy_fn_data_name = "getPageHierarchyTree"
+'''
+The name of the JavaScript function that returns the ``json`` data associated with the
+**Page** Hierarchy when :data:`~exhale.configs.createTreeView` is ``True`` **and**
 :data:`~exhale.configs.treeViewIsBootstrap` is ``True``.
 '''
 
@@ -1310,7 +1337,6 @@ def apply_sphinx_configurations(app):
     req_kv = [
         ("containmentFolder",    six.string_types,  True),
         ("rootFileName",         six.string_types, False),
-        ("rootFileTitle",        six.string_types, False),
         ("doxygenStripFromPath", six.string_types,  True)
     ]
     for key, expected_type, make_absolute in req_kv:
@@ -1402,12 +1428,14 @@ def apply_sphinx_configurations(app):
     ####################################################################################
     # TODO: `list` -> `(list, tuple)`, update docs too.
     opt_kv = [
+        ("rootFileTitle",                   six.string_types),
         # Build Process Logging, Colors, and Debugging
         ("verboseBuild",                                bool),
         ("alwaysColorize",                              bool),
         ("generateBreatheFileDirectives",               bool),
         # Root API Document Customization and Treeview
         ("afterTitleDescription",           six.string_types),
+        ("pageHierarchySubSectionTitle",    six.string_types),
         ("afterHierarchyDescription",       six.string_types),
         ("fullApiSubSectionTitle",          six.string_types),
         ("afterBodySummary",                six.string_types),

--- a/exhale/deploy.py
+++ b/exhale/deploy.py
@@ -376,8 +376,6 @@ def explode():
         raise RuntimeError(err_msg.format(config="containmentFolder"))
     if configs.rootFileName is None:
         raise RuntimeError(err_msg.format(config="rootFileName"))
-    if configs.rootFileTitle is None:
-        raise RuntimeError(err_msg.format(config="rootFileTitle"))
     if configs.doxygenStripFromPath is None:
         raise RuntimeError(err_msg.format(config="doxygenStripFromPath"))
 

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -159,6 +159,7 @@ class ExhaleNode(object):
         self.name        = os.path.normpath(name) if kind == 'dir' else name
         self.kind        = kind
         self.refid       = refid
+        self.root_owner  = None  # the ExhaleRoot owner
 
         self.template_params = []  # only populated if found
 
@@ -178,6 +179,7 @@ class ExhaleNode(object):
         self.link_name   = None
         self.title       = None
         # representation of hierarchies
+        self.in_page_hierarchy = False
         self.in_class_hierarchy = False
         self.in_file_hierarchy = False
         # kind-specific additional information
@@ -210,7 +212,24 @@ class ExhaleNode(object):
         '''
         # allows alphabetical sorting within types
         if self.kind == other.kind:
-            return self.name.lower() < other.name.lower()
+            if self.kind != "page":
+                return self.name.lower() < other.name.lower()
+            else:
+                # Arbitrarily stuff "indexpage" refid to the front.  As doxygen presents
+                # things, it shows up last, but it does not matter since the sort we
+                # really care about will be with lists that do *NOT* have indexpage in
+                # them (for creating the page view hierarchy).
+                if self.refid == "indexpage":
+                    return True
+                elif other.refid == "indexpage":
+                    return False
+
+                # NOTE: kind of wasteful, but ordered_refs has ALL pages
+                # but realistically, there wont be *that* many pages. right? ;)
+                ordered_refs = [
+                    p.refid for p in self.root_owner.index_xml_page_ordering
+                ]
+                return ordered_refs.index(self.refid) < ordered_refs.index(other.refid)
         # treat structs and classes as the same type
         elif self.kind == "struct" or self.kind == "class":
             if other.kind != "struct" and other.kind != "class":
@@ -225,6 +244,11 @@ class ExhaleNode(object):
         # otherwise, sort based off the kind
         else:
             return self.kind < other.kind
+
+    def set_owner(self, root):
+        """Sets the :class:`~exhale.graph.ExhaleRoot` owner ``self.root_owner``."""
+        # needed to be able to track the page orderings as presented in index.xml
+        self.root_owner = root
 
     def breathe_identifier(self):
         """
@@ -564,6 +588,19 @@ class ExhaleNode(object):
         for c in self.children:
             c.typeSort()
 
+    def inPageHierarchy(self):
+        '''
+        Whether or not this node should be included in the page view hierarchy.  Helper
+        method for :func:`~exhale.graph.ExhaleNode.toHierarchy`.  Sets the member
+        variable ``self.in_page_hierarchy`` to True if appropriate.
+
+        :Return (bool):
+            True if this node should be included in the page view --- if it is a
+            node of kind ``page``. Returns False otherwise.
+        '''
+        self.in_page_hierarchy = self.kind == "page"
+        return self.in_page_hierarchy
+
     def inClassHierarchy(self):
         '''
         Whether or not this node should be included in the class view hierarchy.  Helper
@@ -615,14 +652,24 @@ class ExhaleNode(object):
                     return True
         return False
 
-    def inHierarchy(self, classView):
-        if classView:
+    def inHierarchy(self, hierarchyType):
+        if hierarchyType == "page":
+            return self.inPageHierarchy()
+        elif hierarchyType == "class":
             return self.inClassHierarchy()
-        else:
+        elif hierarchyType == "file":
             return self.inFileHierarchy()
+        else:
+            raise RuntimeError("'{}' is not a valid hierarchy type".format(hierarchyType))
 
-    def hierarchySortedDirectDescendants(self, classView):
-        if classView:
+    def hierarchySortedDirectDescendants(self, hierarchyType):
+        if hierarchyType == "page":
+            if self.kind != "page":
+                raise RuntimeError(
+                    "Page hierarchies do not apply to '{}' nodes".format(self.kind)
+                )
+            return sorted(self.children)
+        elif hierarchyType == "class":
             # search for nested children to display as sub-items in the tree view
             if self.kind == "class" or self.kind == "struct":
                 # first find all of the relevant children
@@ -654,7 +701,7 @@ class ExhaleNode(object):
                 nested_nspaces = []
                 nested_kids    = []
                 for c in self.children:
-                    if c.inHierarchy(classView):
+                    if c.inHierarchy(hierarchyType):
                         if c.kind == "namespace":
                             nested_nspaces.append(c)
                         else:
@@ -671,14 +718,13 @@ class ExhaleNode(object):
             else:
                 # everything else is a terminal node
                 return []
-        # file view hierarchy
-        else:
+        elif hierarchyType == "file":
             if self.kind == "dir":
                 # find the nested children of interest
                 nested_dirs = []
                 nested_kids = []
                 for c in self.children:
-                    if c.inHierarchy(classView):
+                    if c.inHierarchy(hierarchyType):
                         if c.kind == "dir":
                             nested_dirs.append(c)
                         elif c.kind == "file":
@@ -695,12 +741,16 @@ class ExhaleNode(object):
             else:
                 # files are terminal nodes in this hierarchy view
                 return []
+        else:
+            raise RuntimeError("{} is not a valid hierarchy type".format(hierarchyType))
 
-    def toHierarchy(self, classView, level, stream, lastChild=False):
+    def toHierarchy(self, hierarchyType, level, stream, lastChild=False):
         '''
         **Parameters**
-            ``classView`` (bool)
-                ``True`` if generating the Class Hierarchy, ``False`` for File Hierarchy.
+            ``hierarchyType`` (str)
+                ``"page"`` if generating the Page Hierarchy,
+                ``"class"`` if generating the Class Hierarchy,
+                ``"file"`` if generating the File Hierarchy.
 
             ``level`` (int)
                 Recursion level used to determine indentation.
@@ -716,10 +766,21 @@ class ExhaleNode(object):
 
         .. todo:: add thorough documentation of this
         '''
-        if self.inHierarchy(classView):
+        # NOTE: indexpage needs to be treated specially, you need to include the
+        # children at the *same* level, and not actually include indexpage.
+        if hierarchyType == "page" and self.refid == "indexpage":
+            nested_children = self.hierarchySortedDirectDescendants(hierarchyType)
+            last_child_index = len(nested_children) - 1
+            child_idx        = 0
+            for child in nested_children:
+                child.toHierarchy(
+                    hierarchyType, level, stream, child_idx == last_child_index)
+                child_idx += 1
+            return
+        if self.inHierarchy(hierarchyType):
             # For the Tree Views, we need to know if there are nested children before
             # writing anything.  If there are, we need to open a new list
-            nested_children = self.hierarchySortedDirectDescendants(classView)
+            nested_children = self.hierarchySortedDirectDescendants(hierarchyType)
 
             ############################################################################
             # Write out this node.                                                     #
@@ -744,20 +805,26 @@ class ExhaleNode(object):
                     anchor=html_link
                 )
 
-                # should always have at least two parts (templates will have more)
-                title_as_link_parts = self.title.split(" ")
-                if self.template_params:
-                    # E.g. 'Template Class Foo'
-                    q_start = 0
-                    q_end   = 2
+                if self.kind != "page":
+                    # should always have at least two parts (templates will have more)
+                    title_as_link_parts = self.title.split(" ")
+                    if self.template_params:
+                        # E.g. 'Template Class Foo'
+                        q_start = 0
+                        q_end   = 2
+                    else:
+                        # E.g. 'Class Foo'
+                        q_start = 0
+                        q_end   = 1
+                    # the qualifier will not be part of the hyperlink (for clarity of
+                    # navigation), the link_title will be
+                    qualifier   = " ".join(title_as_link_parts[q_start:q_end])
+                    link_title  = " ".join(title_as_link_parts[q_end:])
                 else:
-                    # E.g. 'Class Foo'
-                    q_start = 0
-                    q_end   = 1
-                # the qualifier will not be part of the hyperlink (for clarity of
-                # navigation), the link_title will be
-                qualifier   = " ".join(title_as_link_parts[q_start:q_end])
-                link_title  = " ".join(title_as_link_parts[q_end:])
+                    # E.g. 'Foo'
+                    qualifier = ""
+                    link_title = self.title
+
                 link_title  = link_title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
                 # the actual text / link inside of the list item
                 li_text     = '{qualifier} <a href="{href}">{link_title}</a>'.format(
@@ -840,7 +907,7 @@ class ExhaleNode(object):
             last_child_index = len(nested_children) - 1
             child_idx        = 0
             for child in nested_children:
-                child.toHierarchy(classView, level + 1, stream, child_idx == last_child_index)
+                child.toHierarchy(hierarchyType, level + 1, stream, child_idx == last_child_index)
                 child_idx += 1
 
             ############################################################################
@@ -966,6 +1033,7 @@ class ExhaleRoot(object):
         self.root_directory         = configs.containmentFolder
         self.root_file_name         = configs.rootFileName
         self.full_root_file_path    = os.path.join(self.root_directory, self.root_file_name)
+        self.page_hierarchy_file    = os.path.join(self.root_directory, "page_view_hierarchy.rst")
         self.class_hierarchy_file   = os.path.join(self.root_directory, "class_view_hierarchy.rst")
         self.file_hierarchy_file    = os.path.join(self.root_directory, "file_view_hierarchy.rst")
         self.unabridged_api_file    = os.path.join(self.root_directory, "unabridged_api.rst")
@@ -1016,7 +1084,14 @@ class ExhaleRoot(object):
         self.unions          = []           # |
         # doxygenvariable  <-+-> "variable"   |
         self.variables       = []           # |
+        # doxygenpage      <-+-> "page"       |
+        self.pages           = []           # |
         # -------------------+----------------+
+        # tracks the named ordering of pages as they show up in index.xml
+        # so that the page hierarchy can be presented in the same order.
+        # the only node not placed in here is "indexpage" since it is not
+        # included in the page view hierarchy (indexpage is dumped right above)
+        self.index_xml_page_ordering = []
 
     ####################################################################################
     #
@@ -1115,6 +1190,75 @@ class ExhaleRoot(object):
                                 child_node.def_in_file = curr_node
 
                             curr_node.children.append(child_node)
+
+        for page in self.pages:
+            node_xml_contents = utils.nodeCompoundXMLContents(page)
+            if node_xml_contents:
+                try:
+                    page.soup = BeautifulSoup(node_xml_contents, "lxml-xml")
+                except:
+                    utils.fancyError("Unable to parse file xml [{0}]:".format(page.name))
+
+                try:
+                    cdef = page.soup.doxygen.compounddef
+
+                    title = cdef.find("title")
+                    if title and title.string:
+                        page.title = title.string
+
+                    err_non = "[CRITICAL] did not find refid [{0}] in `self.node_by_refid`."
+                    err_dup = "Conflicting page definition: [{0}] appears to be defined in both [{1}] and [{2}]."  # noqa
+                    # process subpages
+                    inner_pages = cdef.find_all("innerpage", recursive=False)
+
+                    utils.verbose_log(
+                        "*** [{0}] had [{1}] innerpages found".format(page.name, len(inner_pages)),
+                        utils.AnsiColors.BOLD_MAGENTA
+                    )
+
+                    for subpage in inner_pages:
+                        if "refid" in subpage.attrs:
+                            refid = subpage.attrs["refid"]
+                            if refid in self.node_by_refid:
+                                node = self.node_by_refid[refid]
+
+                                # << verboseBuild
+                                utils.verbose_log(
+                                    "    - [{0}]".format(node.name),
+                                    utils.AnsiColors.BOLD_MAGENTA
+                                )
+
+                                if node.parent:
+                                    utils.verbose_log(
+                                        err_dup.format(node.name, node.parent.name, page.name),
+                                        utils.AnsiColors.BOLD_YELLOW
+                                    )
+
+                                if node not in page.children:
+                                    page.children.append(node)
+                                    node.parent = page
+                            else:
+                                # << verboseBuild
+                                utils.verbose_log(err_non.format(refid), utils.AnsiColors.BOLD_RED)
+
+                    # the location of the page as determined by doxygen
+                    location = cdef.find("location")
+                    if location and "file" in location.attrs:
+                        location_str = os.path.normpath(location.attrs["file"])
+                        # some older versions of doxygen don't reliably strip from path
+                        # so make sure to remove it
+                        abs_strip_path = os.path.normpath(os.path.abspath(
+                            configs.doxygenStripFromPath
+                        ))
+                        if location_str.startswith(abs_strip_path):
+                            location_str = os.path.relpath(location_str, abs_strip_path)
+                        page.location = os.path.normpath(location_str)
+
+                except:
+                    utils.fancyError(
+                        "Could not process Doxygen xml for file [{0}]".format(f.name)
+                    )
+        self.pages = [page for page in self.pages if not page.parent]
 
         # Now that we have discovered everything, we need to explicitly parse the file
         # xml documents to determine where leaf-like nodes have been declared.
@@ -1492,6 +1636,7 @@ class ExhaleRoot(object):
                 The node to begin tracking if not already present.
         '''
         if node not in self.all_nodes:
+            node.set_owner(self)
             self.all_nodes.append(node)
             self.node_by_refid[node.refid] = node
             if node.kind == "class" or node.kind == "struct":
@@ -1518,6 +1663,10 @@ class ExhaleRoot(object):
                 self.typedefs.append(node)
             elif node.kind == "union":
                 self.unions.append(node)
+            elif node.kind == "page":
+                self.pages.append(node)
+                if node.refid != "indexpage":
+                    self.index_xml_page_ordering.append(node)
 
     def reparentAll(self):
         '''
@@ -2041,6 +2190,7 @@ class ExhaleRoot(object):
         self.groups.sort()
         self.typedefs.sort()
         self.variables.sort()
+        self.pages.sort()
 
         # hierarchical lists: sort children
         self.deepSortList(self.class_like)
@@ -2048,6 +2198,7 @@ class ExhaleRoot(object):
         self.deepSortList(self.unions)
         self.deepSortList(self.files)
         self.deepSortList(self.dirs)
+        self.deepSortList(self.pages)
 
     def deepSortList(self, lst):
         '''
@@ -2077,8 +2228,8 @@ class ExhaleRoot(object):
 
         1. Generate a single file restructured text document for all of the nodes that
            have either no children, or children that are leaf nodes.
-        2. When building the view hierarchies (class view and file view), provide a link
-           to the appropriate files generated previously.
+        2. When building the view hierarchies (page, class, and file view and), provide
+           a link to the appropriate files generated previously.
 
         If adding onto the framework to say add another view (from future import groups)
         you would link from a restructured text document to one of the individually
@@ -2115,17 +2266,19 @@ class ExhaleRoot(object):
                 if configs.pageLevelConfigMeta:
                     generated_index.write("{0}\n\n".format(configs.pageLevelConfigMeta))
 
-                generated_index.write(textwrap.dedent('''
-                    {heading}
-                    {heading_mark}
+                if configs.rootFileTitle:
+                    generated_index.write(textwrap.dedent('''\
+                        {heading_mark}
+                        {heading}
+                        {heading_mark}
 
-                '''.format(
-                    heading=configs.rootFileTitle,
-                    heading_mark=utils.heading_mark(
-                        configs.rootFileTitle,
-                        configs.SECTION_HEADING_CHAR
-                    )
-                )))
+                    '''.format(
+                        heading=configs.rootFileTitle,
+                        heading_mark=utils.heading_mark(
+                            configs.rootFileTitle,
+                            configs.SECTION_HEADING_CHAR
+                        )
+                    )))
 
                 if configs.afterTitleDescription:
                     generated_index.write("\n{0}\n\n".format(configs.afterTitleDescription))
@@ -2173,6 +2326,8 @@ class ExhaleRoot(object):
             if node.kind in utils.LEAF_LIKE_KINDS:
                 self.generateSingleNodeRST(node)
 
+        self.generatePageDocuments()
+
         # generate the remaining parent-like documents
         self.generateNamespaceNodeDocuments()
         self.generateFileNodeDocuments()
@@ -2212,7 +2367,7 @@ class ExhaleRoot(object):
         # namespace directive.  As such, where possible, the filename should be as
         # human-friendly has possible so that users can conveniently link to the
         # internal Exhal ref's using e.g. :ref:`file_dir_subdir_filename.h`.
-        SPECIAL_CASES = ["dir", "file", "namespace"]
+        SPECIAL_CASES = ["dir", "file", "namespace", "page"]
         if node.kind in SPECIAL_CASES:
             if node.kind == "file":
                 unique_id = node.location
@@ -2326,10 +2481,11 @@ class ExhaleRoot(object):
             title = node.name
 
         # Last but not least, set the title for the page to be generated.
-        node.title = "{kind} {title}".format(
-            kind=utils.qualifyKind(node.kind),
-            title=title
-        )
+        if node.kind != "page":
+            node.title = "{kind} {title}".format(
+                kind=utils.qualifyKind(node.kind),
+                title=title
+            )
         if node.template_params or template_special:
             node.title = "Template {title}".format(title=node.title)
 
@@ -2658,6 +2814,72 @@ class ExhaleRoot(object):
                     breathe_identifier=node.breathe_identifier()
                 )
                 gen_file.write("\n{directive}\n".format(directive=directive))
+                # include any specific directives for this doxygen directive
+                specifications = utils.prefix(
+                    "   ",
+                    "\n".join(spec for spec in utils.specificationsForKind(node.kind))
+                )
+                gen_file.write(specifications)
+        except:
+            utils.fancyError(
+                "Critical error while generating the file for [{0}].".format(node.file_name)
+            )
+
+    def generatePageDocuments(self):
+        '''
+        Generates the reStructuredText document for every page.
+        '''
+        all_pages = [p for p in self.pages]
+        while len(all_pages) > 0:
+            page = all_pages.pop()
+            self.generateSinglePageDocument(page)
+            for subpage in page.children:
+                all_pages.append(subpage)
+
+    def generateSinglePageDocument(self, node):
+        '''
+        Creates the reStructuredText document for a page.
+
+        :Parameters:
+            ``node`` (ExhaleNode)
+                The "page" node being generated by this method.
+        '''
+        try:
+            with codecs.open(node.file_name, "w", "utf-8") as gen_file:
+                ########################################################################
+                # Page header / linking.                                               #
+                ########################################################################
+                # generate a link label for every generated file
+                link_declaration = ".. _{0}:".format(node.link_name)
+
+                # Add the metadata if they requested it
+                if configs.pageLevelConfigMeta:
+                    gen_file.write("{0}\n\n".format(configs.pageLevelConfigMeta))
+
+                gen_file.write(textwrap.dedent('''\
+                    {link}
+
+                    {heading}
+                    {heading_mark}
+
+                '''.format(
+                    link=link_declaration,
+                    heading=node.title,
+                    heading_mark=utils.heading_mark(
+                        node.title, configs.SECTION_HEADING_CHAR
+                    )
+                )))
+
+                contents = utils.contentsDirectiveOrNone(node.kind)
+                if contents:
+                    gen_file.write(contents)
+
+                # inject the appropriate doxygen directive and name of this node
+                directive = ".. {directive}:: {breathe_identifier}".format(
+                    directive=utils.kindAsBreatheDirective(node.kind),
+                    breathe_identifier=node.breathe_identifier()
+                )
+                gen_file.write("{directive}\n".format(directive=directive))
                 # include any specific directives for this doxygen directive
                 specifications = utils.prefix(
                     "   ",
@@ -3258,9 +3480,10 @@ class ExhaleRoot(object):
         hierarchies as well as the full API listing.  As a result, three files will now
         be ready:
 
-        1. ``self.class_hierarchy_file``
-        2. ``self.file_hierarchy_file``
-        3. ``self.unabridged_api_file``
+        1. ``self.page_hierarchy_file``
+        2. ``self.class_hierarchy_file``
+        3. ``self.file_hierarchy_file``
+        4. ``self.unabridged_api_file``
 
         These three files are then *included* into the root library file.  The
         consequence of using an ``include`` directive is that Sphinx will complain about
@@ -3276,13 +3499,26 @@ class ExhaleRoot(object):
             self.generateViewHierarchies()
             self.generateUnabridgedAPI()
             with codecs.open(self.full_root_file_path, "a", "utf-8") as generated_index:
-                # Include the class and file hierarchies
-                generated_index.write(".. include:: {0}\n\n".format(
-                    os.path.basename(self.class_hierarchy_file)
-                ))
-                generated_index.write(".. include:: {0}\n\n".format(
-                    os.path.basename(self.file_hierarchy_file)
-                ))
+                # Include index page, if present
+                for page in self.pages:
+                    if page.refid == "indexpage":
+                        generated_index.write(".. include:: {0}\n\n".format(
+                            os.path.basename(page.file_name)
+                        ))
+                        break
+                # Include the page, class, and file hierarchies
+                if any(node.kind == "page" for node in self.all_nodes):
+                    generated_index.write(".. include:: {0}\n\n".format(
+                        os.path.basename(self.page_hierarchy_file)
+                    ))
+                if any(node.kind in utils.CLASS_LIKE_KINDS for node in self.all_nodes):
+                    generated_index.write(".. include:: {0}\n\n".format(
+                        os.path.basename(self.class_hierarchy_file)
+                    ))
+                if any(node.kind in {"dir", "file"} for node in self.all_nodes):
+                    generated_index.write(".. include:: {0}\n\n".format(
+                        os.path.basename(self.file_hierarchy_file)
+                    ))
 
                 # Add the afterHierarchyDescription if provided
                 if configs.afterHierarchyDescription:
@@ -3336,6 +3572,18 @@ class ExhaleRoot(object):
                                     */
                                     // Part 1: use linkColor as a parameter to bootstrap treeview
 
+                                    // apply the page view hierarchy
+                                    $("#{page_idx}").treeview({{
+                                        data: {page_func_name}(),
+                                        enableLinks: true,
+                                        color: linkColor,
+                                        showTags: {show_tags},
+                                        collapseIcon: "{collapse_icon}",
+                                        expandIcon: "{expand_icon}",
+                                        levels: {levels},
+                                        onhoverColor: "{onhover_color}"
+                                    }});
+
                                     // apply the class view hierarchy
                                     $("#{class_idx}").treeview({{
                                         data: {class_func_name}(),
@@ -3370,6 +3618,8 @@ class ExhaleRoot(object):
                            </script>
                     '''.format(
                         icon_mimic=configs.treeViewBootstrapIconMimicColor,
+                        page_idx=configs._page_hierarchy_id,
+                        page_func_name=configs._bstrap_page_hierarchy_fn_data_name,
                         class_idx=configs._class_hierarchy_id,
                         class_func_name=configs._bstrap_class_hierarchy_fn_data_name,
                         file_idx=configs._file_hierarchy_id,
@@ -3401,20 +3651,42 @@ class ExhaleRoot(object):
     def generateViewHierarchies(self):
         '''
         Wrapper method to create the view hierarchies.  Currently it just calls
-        :func:`~exhale.graph.ExhaleRoot.generateClassView` and
+        :func:`~exhale.graph.ExhaleRoot.generatePageView`,
+        :func:`~exhale.graph.ExhaleRoot.generateClassView`, and
         :func:`~exhale.graph.ExhaleRoot.generateDirectoryView` --- if you want to implement
         additional hierarchies, implement the additionaly hierarchy method and call it
         from here.  Then make sure to ``include`` it in
         :func:`~exhale.graph.ExhaleRoot.generateAPIRootBody`.
         '''
+        # gather the page hierarchy data and write it out
+        page_view_data = self.generatePageView()
+        self.writeOutHierarchy({
+            "idx": configs._page_hierarchy_id,
+            "bstrap_data_func_name": configs._bstrap_page_hierarchy_fn_data_name,
+            "file_name": self.page_hierarchy_file,
+            "file_title": configs.pageHierarchySubSectionTitle,
+            "type": "page"
+        }, page_view_data)
         # gather the class hierarchy data and write it out
         class_view_data = self.generateClassView()
-        self.writeOutHierarchy(True, class_view_data)
+        self.writeOutHierarchy({
+            "idx": configs._class_hierarchy_id,
+            "bstrap_data_func_name": configs._bstrap_class_hierarchy_fn_data_name,
+            "file_name": self.class_hierarchy_file,
+            "file_title": "Class Hierarchy",
+            "type": "class"
+        }, class_view_data)
         # gather the file hierarchy data and write it out
         file_view_data = self.generateDirectoryView()
-        self.writeOutHierarchy(False, file_view_data)
+        self.writeOutHierarchy({
+            "idx": configs._file_hierarchy_id,
+            "bstrap_data_func_name": configs._bstrap_file_hierarchy_fn_data_name,
+            "file_name": self.file_hierarchy_file,
+            "file_title": "File Hierarchy",
+            "type": "file"
+        }, file_view_data)
 
-    def writeOutHierarchy(self, classView, data):
+    def writeOutHierarchy(self, hierarchy_config, data):
         # inject the raw html for the treeView unordered lists
         if configs.createTreeView:
             # Cheap minification.  The `data` string is either
@@ -3433,98 +3705,104 @@ class ExhaleRoot(object):
                 if configs.treeViewIsBootstrap:
                     data = data.replace(': ', ':').replace(",}", "}").replace(",,", ",").replace(",]", "]")
 
-            # conveniently, both get indented to the same level.  a happy accident
-            indent = " " * 9  # indent by 6 + 3 for being under .. raw:: html
-            indented_data = re.sub(r'(.+)', r'{indent}\1'.format(indent=indent), data)
-            if classView:
-                idx = configs._class_hierarchy_id
-            else:
-                idx = configs._file_hierarchy_id
+            if data:
+                # conveniently, both get indented to the same level.  a happy accident
+                indent = " " * 9  # indent by 6 + 3 for being under .. raw:: html
+                indented_data = re.sub(r'(.+)', r'{indent}\1'.format(indent=indent), data)
+                idx = hierarchy_config["idx"]
 
-            final_data_stream = StringIO()
-            if configs.treeViewIsBootstrap:
-                if classView:
-                    func_name = configs._bstrap_class_hierarchy_fn_data_name
+                final_data_stream = StringIO()
+                if configs.treeViewIsBootstrap:
+                    func_name = hierarchy_config["bstrap_data_func_name"]
+                    # developer note: when using string formatting with {curly_braces}, if
+                    # you want a literal curly brace you escape it with curly braces.  so
+                    # the left curly brace is `{{` rather than `{` so that the formatting
+                    # knows you want a literal `{` in the end.
+                    final_data_stream.write(textwrap.dedent('''
+                        .. raw:: html
+
+                           <div id="{idx}"></div>
+                           <script type="text/javascript">
+                             function {func_name}() {{
+                                return [
+                    '''.format(idx=idx, func_name=func_name)))
+                    final_data_stream.write(indented_data)
+                    # NOTE: the final .. end raw html line "tricks" textwrap.dedent into
+                    #       only stripping out until there. DO NOT REMOVE EVER!
+                    final_data_stream.write(textwrap.dedent('''
+                                ]
+                             }}
+                           </script><!-- end {func_name}() function -->
+
+                        .. end raw html for treeView
+                    '''.format(idx=idx, func_name=func_name)))
                 else:
-                    func_name = configs._bstrap_file_hierarchy_fn_data_name
-                # developer note: when using string formatting with {curly_braces}, if
-                # you want a literal curly brace you escape it with curly braces.  so
-                # the left curly brace is `{{` rather than `{` so that the formatting
-                # knows you want a literal `{` in the end.
-                final_data_stream.write(textwrap.dedent('''
-                    .. raw:: html
+                    final_data_stream.write(textwrap.dedent('''
+                        .. raw:: html
 
-                       <div id="{idx}"></div>
-                       <script type="text/javascript">
-                         function {func_name}() {{
-                            return [
-                '''.format(idx=idx, func_name=func_name)))
-                final_data_stream.write(indented_data)
-                # NOTE: the final .. end raw html line "tricks" textwrap.dedent into
-                #       only stripping out until there. DO NOT REMOVE EVER!
-                final_data_stream.write(textwrap.dedent('''
-                            ]
-                         }}
-                       </script><!-- end {func_name}() function -->
+                           <ul class="treeView" id="{idx}">
+                             <li>
+                               <ul class="collapsibleList">
+                    '''.format(idx=idx)))
+                    final_data_stream.write(indented_data)
+                    # NOTE: the final .. end raw html line "tricks" textwrap.dedent into
+                    #       only stripping out until there. DO NOT REMOVE EVER!
+                    final_data_stream.write(textwrap.dedent('''
+                               </ul>
+                             </li><!-- only tree view element -->
+                           </ul><!-- /treeView {idx} -->
 
-                    .. end raw html for treeView
-                '''.format(idx=idx, func_name=func_name)))
+                        .. end raw html for treeView
+                    '''.format(idx=idx)))
+
+                # the appropriate raw html has been created, grab the final value
+                final_data_string = final_data_stream.getvalue()
+                final_data_stream.close()
             else:
-                final_data_stream.write(textwrap.dedent('''
-                    .. raw:: html
-
-                       <ul class="treeView" id="{idx}">
-                         <li>
-                           <ul class="collapsibleList">
-                '''.format(idx=idx)))
-                final_data_stream.write(indented_data)
-                # NOTE: the final .. end raw html line "tricks" textwrap.dedent into
-                #       only stripping out until there. DO NOT REMOVE EVER!
-                final_data_stream.write(textwrap.dedent('''
-                           </ul>
-                         </li><!-- only tree view element -->
-                       </ul><!-- /treeView {idx} -->
-
-                    .. end raw html for treeView
-                '''.format(idx=idx)))
-
-            # the appropriate raw html has been created, grab the final value
-            final_data_string = final_data_stream.getvalue()
-            final_data_stream.close()
+                final_data_string = data
         else:
             # non-treeView is already done formatting, just a bulleted list
             final_data_string = data
 
         # Last but not least, we need the file to write to
-        if classView:
-            file_name  = self.class_hierarchy_file
-            file_title = "Class Hierarchy"
-        else:
-            file_name  = self.file_hierarchy_file
-            file_title = "File Hierarchy"
+        file_name = hierarchy_config["file_name"]
 
         # write everything to file to be incorporated with `.. include::` later
         try:
             with codecs.open(file_name, "w", "utf-8") as hierarchy_file:
-                hierarchy_file.write(textwrap.dedent('''
-                    {heading}
-                    {heading_mark}
+                if final_data_string:
+                    file_title = hierarchy_config["file_title"]
+                    hierarchy_file.write(textwrap.dedent('''
+                        {heading}
+                        {heading_mark}
 
-                ''').format(
-                    heading=file_title,
-                    heading_mark=utils.heading_mark(
-                        file_title,
-                        configs.SUB_SECTION_HEADING_CHAR
-                    )
-                ))
-                hierarchy_file.write(final_data_string)
-                hierarchy_file.write("\n\n")  # just in case, extra whitespace causes no harm
+                    ''').format(
+                        heading=file_title,
+                        heading_mark=utils.heading_mark(
+                            file_title,
+                            configs.SUB_SECTION_HEADING_CHAR
+                        )
+                    ))
+                    hierarchy_file.write(final_data_string)
+                    hierarchy_file.write("\n\n")  # just in case, extra whitespace causes no harm
         except:
-            if classView:
-                h_type = "class"
-            else:
-                h_type = "file"
+            h_type = hierarchy_config["type"]
             utils.fancyError("Error writing the {h_type} hierarchy.".format(h_type=h_type))
+
+    def generatePageView(self):
+        '''
+        Generates the pages view hierarchy, writing it to ``self.page_hierarchy_file``.
+        '''
+        page_view_stream = StringIO()
+
+        for p in self.pages:
+            p.toHierarchy("page", 0, page_view_stream)
+
+        # extract the value from the stream and close it down
+        page_view_string = page_view_stream.getvalue()
+        page_view_stream.close()
+
+        return page_view_string
 
     def generateClassView(self):
         '''
@@ -3533,7 +3811,7 @@ class ExhaleRoot(object):
         class_view_stream = StringIO()
 
         for n in self.namespaces:
-            n.toHierarchy(True, 0, class_view_stream)
+            n.toHierarchy("class", 0, class_view_stream)
 
         # Add everything that was not nested in a namespace.
         missing = []
@@ -3554,7 +3832,7 @@ class ExhaleRoot(object):
             idx = 0
             last_missing_child = len(missing) - 1
             for m in missing:
-                m.toHierarchy(True, 0, class_view_stream, idx == last_missing_child)
+                m.toHierarchy("class", 0, class_view_stream, idx == last_missing_child)
                 idx += 1
         elif configs.createTreeView:
             # need to restart since there were no missing children found, otherwise the
@@ -3565,7 +3843,7 @@ class ExhaleRoot(object):
             last_nspace_index = len(self.namespaces) - 1
             for idx in range(last_nspace_index + 1):
                 nspace = self.namespaces[idx]
-                nspace.toHierarchy(True, 0, class_view_stream, idx == last_nspace_index)
+                nspace.toHierarchy("class", 0, class_view_stream, idx == last_nspace_index)
 
         # extract the value from the stream and close it down
         class_view_string = class_view_stream.getvalue()
@@ -3579,7 +3857,7 @@ class ExhaleRoot(object):
         file_view_stream = StringIO()
 
         for d in self.dirs:
-            d.toHierarchy(False, 0, file_view_stream)
+            d.toHierarchy("file", 0, file_view_stream)
 
         # add potential missing files (not sure if this is possible though)
         missing = []
@@ -3592,7 +3870,7 @@ class ExhaleRoot(object):
             idx = 0
             last_missing_child = len(missing) - 1
             for m in missing:
-                m.toHierarchy(False, 0, file_view_stream, idx == last_missing_child)
+                m.toHierarchy("file", 0, file_view_stream, idx == last_missing_child)
                 idx += 1
         elif configs.createTreeView:
             # need to restart since there were no missing children found, otherwise the
@@ -3603,7 +3881,7 @@ class ExhaleRoot(object):
             last_dir_index = len(self.dirs) - 1
             for idx in range(last_dir_index + 1):
                 curr_d = self.dirs[idx]
-                curr_d.toHierarchy(False, 0, file_view_stream, idx == last_dir_index)
+                curr_d.toHierarchy("file", 0, file_view_stream, idx == last_dir_index)
 
         # extract the value from the stream and close it down
         file_view_string = file_view_stream.getvalue()
@@ -3682,6 +3960,8 @@ class ExhaleRoot(object):
             # node itself.  "class" and "struct" are stored together.
             unabridged_specs = UnabridgedDict()
             for node in self.all_nodes:
+                if node.kind == "page" and node.refid == "indexpage":
+                    continue
                 unabridged_specs[node.kind].append(node)
 
             # Create the buffers to write to and dump the page headings.
@@ -3712,7 +3992,8 @@ class ExhaleRoot(object):
                 ("Defines", "define"),
                 ("Typedefs", "typedef"),
                 ("Directories", "dir"),
-                ("Files", "file")
+                ("Files", "file"),
+                ("Pages", "page")
             ]
             for title, kind in dump_order:
                 node_list = unabridged_specs[kind]
@@ -3807,7 +4088,8 @@ class ExhaleRoot(object):
             "namespace": utils.AnsiColors.BOLD_CYAN,
             "typedef":   utils.AnsiColors.BOLD_YELLOW,
             "union":     utils.AnsiColors.BOLD_MAGENTA,
-            "variable":  utils.AnsiColors.BOLD_CYAN
+            "variable":  utils.AnsiColors.BOLD_CYAN,
+            "page":      utils.AnsiColors.BOLD_YELLOW
         }
 
         self.consoleFormat(
@@ -3871,6 +4153,11 @@ class ExhaleRoot(object):
         self.consoleFormat(
             utils._use_color("Variables", fmt_spec["variable"], sys.stderr),
             self.variables,
+            fmt_spec
+        )
+        self.consoleFormat(
+            utils._use_color("Pages", fmt_spec["page"], sys.stderr),
+            self.pages,
             fmt_spec
         )
 

--- a/exhale/utils.py
+++ b/exhale/utils.py
@@ -114,7 +114,8 @@ AVAILABLE_KINDS = [
     "struct",
     "typedef",
     "union",
-    "variable"
+    "variable",
+    "page"
 ]
 '''
 All potential input ``kind`` values coming from Doxygen.
@@ -143,6 +144,13 @@ is everything in :data:`AVAILABLE_KINDS`, except for
 
 .. |generateSingleNodeRST| replace:: :class:`ExhaleRoot.generateSingleNodeRST <exhale.graph.ExhaleRoot.generateSingleNodeRST>`
 '''
+
+CLASS_LIKE_KINDS = [
+    "class",
+    "struct",
+    "interface"  # TODO: not currently supported or used
+]
+"""All kinds that are "class-like"."""
 
 
 def contentsDirectiveOrNone(kind):
@@ -471,6 +479,8 @@ def kindAsBreatheDirective(kind):
     | "union"     | "doxygenunion"     |
     +-------------+--------------------+
     | "variable"  | "doxygenvariable"  |
+    +-------------+--------------------+
+    | "page"      | "doxygenpage"      |
     +-------------+--------------------+
 
     The following breathe kinds are ignored:

--- a/testing/projects/cpp_nesting/include/page_town_rock.hpp
+++ b/testing/projects/cpp_nesting/include/page_town_rock.hpp
@@ -1,0 +1,64 @@
+// NOTE: if you change this file, you must make the same changes to the file
+// page_town_rock_alt.hpp.  See also testing/tests/cpp_nesting.py.
+//
+// ONLY the first line of this comment and page_town_rock_alt.hpp should differ.
+/** \mainpage A simple manual
+ *
+ * Some general info.
+ *
+ * \section subpage_list A list of subpages
+ * This manual is divided in the following sections:
+ * - \subpage intro
+ * - \subpage advanced "Advanced usage"
+ *
+ * \section non-op
+ * This section has no explicit title.
+ *
+ * \page intro Introduction
+ * This page introduces the user to the topic.
+ * Now you can proceed to the \ref advanced "advanced section".
+ *
+ * \section howto Tutorial
+ *
+ * \subsection getting_started Getting Started
+ * Just kidding. Go fish!
+ *
+ * \section sub_list_redux Additional Information
+ *
+ * There is more information provided in:
+ *
+ * - \subpage more_nesting
+ * - \subpage more_nesting_redux
+ *
+ * \page advanced Advanced Usage
+ * This page is for advanced users.
+ * Make sure you have first read \ref intro "the introduction".
+ *
+ * \section pre-req Things to know first
+ *
+ * \subsection fair_warning Here Be Dragons
+ * Best to avoid dragons.
+ *
+ * \subsubsection extinction Dragon's are a myth?!
+ * There's an interesting history to the phrase \ref fair_warning "'Here Be
+ * Dragons'"
+ *
+ * \page more_nesting More Information
+ * This page just gives you more information about something you already know.
+ * There can be pages within pages.
+ *
+ * \page more_nesting_redux Even More Information
+ * Look here to see that yet another page has been nested within a page.  Dare we do
+ * it again?  Yes, look for
+ *
+ * - \subpage more_nesting_redux_again
+ * - \subpage more_nesting_redux_again_again
+ *
+ * \page more_nesting_redux_again Too Much Information
+ * A long list of pages is exhausting to process.  Hopefully nobody actually does
+ * this in practice.
+ *
+ * \page more_nesting_redux_again_again Way Too Much Information
+ * Do not forget that this is just a test.  Nothing more, nothing less.  It is not
+ * important what it's contents really are? `;)`
+ */

--- a/testing/projects/cpp_nesting/include/page_town_rock_alt.hpp
+++ b/testing/projects/cpp_nesting/include/page_town_rock_alt.hpp
@@ -1,0 +1,64 @@
+// NOTE: if you change this file, you must make the same changes to the file
+// page_town_rock.hpp.  See also testing/tests/cpp_nesting.py.
+//
+// ONLY the first line of this comment and page_town_rock.hpp should differ.
+/** \page overview A simple manual
+ *
+ * Some general info.
+ *
+ * \section subpage_list A list of subpages
+ * This manual is divided in the following sections:
+ * - \subpage intro
+ * - \subpage advanced "Advanced usage"
+ *
+ * \section non-op
+ * This section has no explicit title.
+ *
+ * \page intro Introduction
+ * This page introduces the user to the topic.
+ * Now you can proceed to the \ref advanced "advanced section".
+ *
+ * \section howto Tutorial
+ *
+ * \subsection getting_started Getting Started
+ * Just kidding. Go fish!
+ *
+ * \section sub_list_redux Additional Information
+ *
+ * There is more information provided in:
+ *
+ * - \subpage more_nesting
+ * - \subpage more_nesting_redux
+ *
+ * \page advanced Advanced Usage
+ * This page is for advanced users.
+ * Make sure you have first read \ref intro "the introduction".
+ *
+ * \section pre-req Things to know first
+ *
+ * \subsection fair_warning Here Be Dragons
+ * Best to avoid dragons.
+ *
+ * \subsubsection extinction Dragon's are a myth?!
+ * There's an interesting history to the phrase \ref fair_warning "'Here Be
+ * Dragons'"
+ *
+ * \page more_nesting More Information
+ * This page just gives you more information about something you already know.
+ * There can be pages within pages.
+ *
+ * \page more_nesting_redux Even More Information
+ * Look here to see that yet another page has been nested within a page.  Dare we do
+ * it again?  Yes, look for
+ *
+ * - \subpage more_nesting_redux_again
+ * - \subpage more_nesting_redux_again_again
+ *
+ * \page more_nesting_redux_again Too Much Information
+ * A long list of pages is exhausting to process.  Hopefully nobody actually does
+ * this in practice.
+ *
+ * \page more_nesting_redux_again_again Way Too Much Information
+ * Do not forget that this is just a test.  Nothing more, nothing less.  It is not
+ * important what it's contents really are? `;)`
+ */

--- a/testing/tests/configs_tree_view.py
+++ b/testing/tests/configs_tree_view.py
@@ -438,6 +438,12 @@ Keys and what they represent:
 """
 
 
+# NOTE: See cpp_nesting.CPPNestingPages.{setUp,tearDown} (creates page_town_rock.hpp).
+@confoverrides(exhale_args={
+    "exhaleDoxygenStdin": dedent("""\
+        INPUT            = ../include
+        EXCLUDE_PATTERNS = */page_town_rock*.hpp
+    """)})
 class TreeViewHierarchyTests(ExhaleTestCase):
     """
     Naive tests on raw "reStructuredText" generated for tree views.

--- a/testing/tests/cpp_nesting.py
+++ b/testing/tests/cpp_nesting.py
@@ -11,12 +11,27 @@ Tests for the ``cpp_nesting`` project.
 
 from __future__ import unicode_literals
 
+import os.path as osp
+from textwrap import dedent
+
+from exhale.utils import heading_mark
+
 from testing.base import ExhaleTestCase
 from testing.decorators import confoverrides
 from testing.hierarchies import                                                        \
-    class_hierarchy, compare_class_hierarchy, compare_file_hierarchy, file_hierarchy
+    class_hierarchy, compare_class_hierarchy, compare_file_hierarchy, file,            \
+    file_hierarchy
 
 
+# NOTE: See setUp / tearDown in CPPNestingPages below.  That file is being
+# generated to test the page hierarchy, but we don't want it included in the
+# tests here which assert the page hierarchy being empty.
+# TODO: assert that the page hierarchy is actually empty.
+@confoverrides(exhale_args={
+    "exhaleDoxygenStdin": dedent("""\
+        INPUT            = ../include
+        EXCLUDE_PATTERNS = */page_town_rock*.hpp
+    """)})
 class CPPNesting(ExhaleTestCase):
     """
     Primary test class for project ``cpp_nesting``.
@@ -29,6 +44,7 @@ class CPPNesting(ExhaleTestCase):
         """Verify the class and file hierarchies."""
         compare_class_hierarchy(self, class_hierarchy(self.class_hierarchy_dict()))
         compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict()))
+        assert len(self.app.exhale_root.pages) == 0  # pages got excluded
 
     @confoverrides(exhale_args={"doxygenStripFromPath": "../include"})
     def test_hierarchies_stripped(self):
@@ -43,3 +59,173 @@ class CPPNesting(ExhaleTestCase):
             no_include = file_hierarchy_dict[key]
             break
         compare_file_hierarchy(self, file_hierarchy(no_include))
+
+
+class CPPNestingPages(ExhaleTestCase):
+    """
+    Primary test class for project ``doxygenpage``.
+
+    .. note::
+
+        Setup for this test is particularly fickle.  There are only two test
+        cases because there are only two file paths we generate.  Order of tests
+        is not guaranteed, so each test needs to exclude it's alternate.  Eww.
+    """
+
+    test_project = "cpp_nesting"
+    """.. testproject:: cpp_nesting"""
+
+    def get_gen_page(self, page):
+        """Return the generated node's rst document text as a string."""
+        gen_file = osp.join(page.root_owner.root_directory, page.file_name)
+        with open(gen_file, "r") as f:
+            return f.read()
+
+    def check_gen_page(self, page):
+        """Verify expected link, title, and directive are on the page."""
+        # NOTE: should *never* be called with p.refid == "indexpage", that is
+        # not generated.
+        page_contents = self.get_gen_page(page)
+        link = "_page_{refid}".format(refid=page.refid)
+        title = "{title}\n{underline}".format(
+            title=page.title, underline=heading_mark(page.title, "="))
+        directive = ".. doxygenpage:: {refid}".format(refid=page.refid)
+        assert link in page_contents
+        assert title in page_contents
+        assert directive in page_contents
+
+    def check_most_pages(self, uses_mainpage=True, main_refid="indexpage"):
+        r"""Check the majority of the page generation.
+
+        **Parameters**
+            uses_mainpage (:class:`python:bool`)
+                Whether or not ``\mainpage`` is used.
+
+            main_refid (:class:`python:str`)
+                If ``uses_mainpage`` is ``False``, then whatever ``\mainpage``
+                was replaced to ``\page {main_refid}``.
+        """
+        # Checks that the right files are included or not included in the library
+        # root document.  Specifically, whether these are found:
+        #
+        #     - .. include:: page_index.rst from doxygen \mainpage
+        #     - .. include:: page_view_hierarchy.rst (from any \page not \mainpage)
+        self.test_common()
+
+        # Make sure nothing changed with the class / file hierarchies.
+        compare_class_hierarchy(self, class_hierarchy(self.class_hierarchy_dict()))
+        file_hierarchy_dict = self.file_hierarchy_dict()
+        include_dir = set(file_hierarchy_dict.keys()).pop()
+        # TODO: make this a parameter if we add more than two tests...
+        if uses_mainpage:
+            f_name = "page_town_rock.hpp"
+        else:
+            f_name = "page_town_rock_alt.hpp"
+        file_hierarchy_dict[include_dir][file(f_name)] = {}
+        compare_file_hierarchy(self, file_hierarchy(file_hierarchy_dict))
+
+        # Validate the misc page hierarchy details.
+        exhale_root = self.app.exhale_root
+        all_pages = [p for p in exhale_root.all_nodes if p.kind == "page"]
+        assert len(all_pages) == 7
+
+        # \mainpage A simple manual
+        # - \subpage intro
+        # - \subpage advanced "Advanced usage"
+        assert len(exhale_root.pages) == 1
+        index = exhale_root.pages[0]
+        assert index.refid == main_refid
+        if not uses_mainpage:
+            self.check_gen_page(index)
+        assert len(index.children) == 2
+        # NOTE: sort should keep intro in front of advanced.
+        index_children = sorted(index.children)
+        assert index_children[0].refid == "intro"
+        assert index_children[1].refid == "advanced"
+
+        # \page intro Introduction
+        # - \subpage more_nesting
+        # - \subpage more_nesting_redux
+        intro = index_children[0]
+        assert len(intro.children) == 2
+        assert intro.children[0].refid == "more_nesting"
+        assert intro.children[1].refid == "more_nesting_redux"
+        self.check_gen_page(intro)
+
+        # \page advanced Advanced Usage
+        advanced = index_children[1]
+        assert len(advanced.children) == 0
+        self.check_gen_page(advanced)
+
+        # \page more_nesting More Information
+        mn = intro.children[0]
+        assert len(mn.children) == 0
+        self.check_gen_page(mn)
+
+        # \page more_nesting_redux Even More Information
+        mnr = intro.children[1]
+        # - \subpage more_nesting_redux_again
+        # - \subpage more_nesting_redux_again_again
+        assert len(mnr.children) == 2
+        assert mnr.children[0].refid == "more_nesting_redux_again"
+        assert mnr.children[1].refid == "more_nesting_redux_again_again"
+        self.check_gen_page(mnr)
+
+        # \page more_nesting_redux_again Too Much Information
+        mnra = mnr.children[0]
+        assert len(mnra.children) == 0
+        self.check_gen_page(mnra)
+
+        # \page more_nesting_redux_again_again Way Too Much Information
+        mnraa = mnr.children[1]
+        assert len(mnraa.children) == 0
+        self.check_gen_page(mnraa)
+
+    @confoverrides(exhale_args={
+        "rootFileTitle": "",
+        "exhaleDoxygenStdin": dedent("""\
+            INPUT            = ../include
+            EXCLUDE_PATTERNS = */page_town_rock_alt.hpp
+        """)})
+    def test_hierarchies_primary_mainpage(self):
+        """Verify the class, file, and page hierarchies."""
+        self.check_most_pages(uses_mainpage=True)
+        # Last but not least, we expect the hierarchy to *not* have indexpage.
+        expected_page_hierarchy = dedent(r"""
+            Page Hierarchy
+            --------------
+
+            - :ref:`page_intro`
+                - :ref:`page_more_nesting`
+                - :ref:`page_more_nesting_redux`
+                    - :ref:`page_more_nesting_redux_again`
+                    - :ref:`page_more_nesting_redux_again_again`
+            - :ref:`page_advanced`
+        """)
+        with open(self.app.exhale_root.page_hierarchy_file, "r") as phf:
+            assert expected_page_hierarchy in phf.read()
+
+    @confoverrides(exhale_args={
+        "exhaleDoxygenStdin": dedent("""\
+            INPUT            = ../include
+            EXCLUDE_PATTERNS = */page_town_rock.hpp
+        """)})
+    def test_hierarchies_primary_no_mainpage(self):
+        """Verify the class, file, and page hierarchies."""
+        self.check_most_pages(uses_mainpage=False, main_refid="overview")
+
+        # Last but not least, we expect the hierarchy to *not* have indexpage.
+        expected_page_hierarchy = dedent(r"""
+            Page Hierarchy
+            --------------
+
+            - :ref:`page_overview`
+                - :ref:`page_intro`
+                    - :ref:`page_more_nesting`
+                    - :ref:`page_more_nesting_redux`
+                        - :ref:`page_more_nesting_redux_again`
+                        - :ref:`page_more_nesting_redux_again_again`
+                - :ref:`page_advanced`
+        """)
+        with open(self.app.exhale_root.page_hierarchy_file, "r") as phf:
+            assert expected_page_hierarchy in phf.read()


### PR DESCRIPTION
Closes #111. This patch is a first stab at supporting Doxygen pages. Namely, it:

- Includes Doxygen's main page in the root file
- Allows page listings in the unabridged API
- Displays a page hierarchy (ignoring the main page)
- Makes the root title optional to avoid duplicates

This is lacking tests (and some existing tests are failing on `master`), but I'd like to get some preliminary feedback. 