### PR TITLE
Escape '*' in template page titles.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ v0.2.4
       `@clalancette <https://github.com/clalancette>`_ for their efforts in improving
       the doxygen-breathe-exhale-sphinx ecosystem (and consequently, encouraging me to
       resume work on this project).
+- Escape ``*`` in template page titles (:pr:`118`).
 
 v0.2.3
 ----------------------------------------------------------------------------------------

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -2487,7 +2487,8 @@ class ExhaleRoot(object):
                 title=title
             )
         if node.template_params or template_special:
-            node.title = "Template {title}".format(title=node.title)
+            node.title = "Template {title}".format(
+                title=node.title.replace('*', '\*'))
 
     def adjustFunctionTitles(self):
         # keys: string (func.name)


### PR DESCRIPTION
Precisely what the title says. Some template partial specializations may contain `*` that if not escaped are confused by `docutils` as *emphasis* syntax.