### PR TITLE
Use the proper beautifulsoup package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-bs4            # BeautifulSoup!
-lxml           # We need the lxml backend for BeautifulSoup.
-sphinx>=1.6.1  # Exhale is a Sphinx extension.  1.6 introduces logging API.
-breathe        # The directives used for documentation come from the excellent Breathe.
-six            # Primarily for Unicode string types
+beautifulsoup4  # BeautifulSoup!
+lxml            # We need the lxml backend for BeautifulSoup.
+sphinx>=1.6.1   # Exhale is a Sphinx extension.  1.6 introduces logging API.
+breathe         # The directives used for documentation come from the excellent Breathe.
+six             # Primarily for Unicode string types


### PR DESCRIPTION
From PyPI's description for `bs4`:

> This package ensures that if you type pip install bs4 by mistake you
> will end up with Beautiful Soup.

Using the proper package makes packaging exhale a little simpler.
