### PR TITLE
restructure testing framework

### DIFF
--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -14,16 +14,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        # os: [macos-latest, ubuntu-latest, windows-latest]
+        # TODO: either obtain doxygen 1.8.20 on mac, or find out why everything
+        # breaks in doxygen 1.9.2.
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       ##########################################################################
       - name: Install Doxygen (macOS)
         if: contains(matrix.os, 'macos')
         run: |
-          brew tap-new $USER/local-doxygen
-          brew extract --version=1.8.20 doxygen $USER/local-doxygen
-          HOMEBREW_NO_AUTO_UPDATE=1 brew install -v doxygen@1.8.20
+          # brew tap-new $USER/local-doxygen
+          # brew extract --version=1.8.20 doxygen $USER/local-doxygen
+          # HOMEBREW_NO_AUTO_UPDATE=1 brew install -v doxygen@1.8.20
+          HOMEBREW_NO_AUTO_UPDATE=1 brew install doxygen
       - name: Install Doxygen (Ubuntu)
         if: contains(matrix.os, 'ubuntu')
         run: |

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -152,5 +152,6 @@ Full Testing Suite Documentation
    testing/decorators
    testing/fixtures
    testing/hierarchies
+   testing/projects
    testing/utils
    testing/tests

--- a/docs/testing/projects.rst
+++ b/docs/testing/projects.rst
@@ -1,0 +1,49 @@
+Testing Projects Module
+========================================================================================
+
+.. automodule:: testing.projects
+   :members:
+
+`` testing.projects.c_maths`` Project
+----------------------------------------------------------------------------------------
+
+.. automodule:: testing.projects.c_maths
+   :members:
+
+`` testing.projects.cpp with spaces`` Project
+----------------------------------------------------------------------------------------
+
+.. module:: testing.projects.cpp_with_spaces
+
+This cannot be documented because it has spaces in the name and autodoc cannot
+complete its import.
+
+`` testing.projects.cpp_fortran_mixed`` Project
+----------------------------------------------------------------------------------------
+
+.. automodule:: testing.projects.cpp_fortran_mixed
+   :members:
+
+`` testing.projects.cpp_func_overloads`` Project
+----------------------------------------------------------------------------------------
+
+.. automodule:: testing.projects.cpp_func_overloads
+   :members:
+
+`` testing.projects.cpp_long_names`` Project
+----------------------------------------------------------------------------------------
+
+.. automodule:: testing.projects.cpp_long_names
+   :members:
+
+`` testing.projects.cpp_nesting`` Project
+----------------------------------------------------------------------------------------
+
+.. automodule:: testing.projects.cpp_nesting
+   :members:
+
+`` testing.projects.cpp_pimpl`` Project
+----------------------------------------------------------------------------------------
+
+.. automodule:: testing.projects.cpp_pimpl
+   :members:

--- a/docs/testproject.py
+++ b/docs/testproject.py
@@ -101,12 +101,16 @@ class TestProjectDirective(Directive):
                 "Example: .. testproject:: c_maths"
             )
         self.content[0] = textwrap.dedent('''\
-            View the `{project} source code here <{baseurl}/{project_dir}>`_.
+            The ``{project}`` test project.
+
+            - Additional documentation: :mod:`testing.projects.{project_fixed}`.
+            - Source code for `{project} available here <{baseurl}/{project_dir}>`_.
 
             See also: :data:`ExhaleTestCase.test_project <testing.base.ExhaleTestCase.test_project>`.
         '''.format(
             project=self.content[0],
             project_dir=self.content[0].replace(" ", "\\ "),
+            project_fixed=self.content[0].replace(" ", "_"),  # cpp with spaces project
             baseurl=get_projects_baseurl()
         ))
         project_node = testproject("\n".join(self.content))

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,8 @@ filterwarnings =
     #   RemovedInSphinx30Warning: function based directive support is now deprecated.
     #                             Use class based directive instead.
     ignore::PendingDeprecationWarning:sphinx.util.docutils
+    # Any import of collections triggers this.
+    ignore: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
 
 [coverage:run]
 data_file = .coverage

--- a/testing/base.py
+++ b/testing/base.py
@@ -18,6 +18,7 @@ import re
 import shutil
 import textwrap
 import unittest
+from importlib import import_module
 
 import exhale
 import pytest
@@ -225,6 +226,25 @@ class ExhaleTestCaseMetaclass(type):
                     self.checkAllFilesIncluded()
 
             attrs["test_common"] = test_common
+
+            # Import the default hierarchy dictionaries from the testing/projects folder
+            # and make it available to the class directly.
+            proj_mod = import_module(
+                "testing.projects.{test_project}".format(test_project=test_project))
+
+            default_class_hierarchy_dict = proj_mod.default_class_hierarchy_dict
+
+            def class_hierarchy_wrapper(self):
+                return default_class_hierarchy_dict()
+            attrs["class_hierarchy_dict"] = class_hierarchy_wrapper
+
+            default_file_hierarchy_dict = proj_mod.default_file_hierarchy_dict
+
+            def file_hierarchy_wrapper(self):
+                return default_file_hierarchy_dict()
+            attrs["file_hierarchy_dict"] = file_hierarchy_wrapper
+
+            attrs["test_project_module"] = proj_mod  # In case it's ever needed...
 
         # applying the default configuration override, which is overridden using the
         # @confoverride decorator at class or method level

--- a/testing/projects/__init__.py
+++ b/testing/projects/__init__.py
@@ -1,0 +1,3 @@
+"""
+The test projects used to evaluate exhale.
+"""

--- a/testing/projects/c_maths/__init__.py
+++ b/testing/projects/c_maths/__init__.py
@@ -1,0 +1,22 @@
+"""
+The ``c_maths`` test project.
+"""
+
+from testing.hierarchies import directory, file, function, parameters
+
+
+def default_class_hierarchy_dict():
+    """Return the default class hierarchy dictionary."""
+    return {}
+
+
+def default_file_hierarchy_dict():
+    """Return the default file hierarchy dictionary."""
+    return {
+        directory("include"): {
+            file("c_maths.h"): {
+                function("int", "cm_add"): parameters("int", "int"),
+                function("int", "cm_sub"): parameters("int", "int")
+            }
+        }
+    }

--- a/testing/projects/cpp with spaces/__init__.py
+++ b/testing/projects/cpp with spaces/__init__.py
@@ -1,0 +1,25 @@
+"""
+The ``cpp with spaces`` test project.
+"""
+
+from testing.hierarchies import directory, file, function, namespace, parameters
+
+
+def default_class_hierarchy_dict():
+    """Return the default class hierarchy dictionary."""
+    return {}
+
+
+def default_file_hierarchy_dict():
+    """Return the default file hierarchy dictionary."""
+    return {
+        directory("include"): {
+            directory("with spaces"): {
+                file("with spaces.hpp"): {
+                    namespace("with_spaces"): {
+                        function("int", "value"): parameters()
+                    }
+                }
+            }
+        }
+    }

--- a/testing/projects/cpp_fortran_mixed/__init__.py
+++ b/testing/projects/cpp_fortran_mixed/__init__.py
@@ -1,0 +1,43 @@
+"""
+The ``cpp_fortran_mixed`` test project.
+"""
+
+from testing.hierarchies import directory, file, function, namespace, parameters, variable
+
+
+def default_class_hierarchy_dict():
+    """Return the default class hierarchy dictionary."""
+    return {}
+
+
+def default_file_hierarchy_dict():
+    """Return the default file hierarchy dictionary."""
+    return {
+        directory("include"): {
+            directory("convert"): {
+                file("convert.hpp"): {
+                    namespace("convert"): {
+                        function("T", "to_degrees", template=["typename T"]): parameters("T"),
+                        function("T", "to_radians", template=["typename T"]): parameters("T")
+                    }
+                }
+            }
+        },
+        directory("src"): {
+            file("conversions.f90"): {
+                namespace("conversions"): {
+                    variable("real(c_float)", "pi_s"): {},
+                    variable("real(c_double)", "pi_d"): {},
+                    variable("real(c_float)", "s_180"): {},
+                    variable("real(c_double)", "d_180"): {},
+                    # NOTE: function parameters in fortran are a little weird.
+                    # 1. <type> has 'function', e.g. 'real(c_float) function'
+                    # 2. Parameters are names, not types?
+                    function("real(c_float) function", "degrees_to_radians_s"): parameters("degrees_s"),
+                    function("real(c_double) function", "degrees_to_radians_d"): parameters("degrees_d"),
+                    function("real(c_float) function", "radians_to_degrees_s"): parameters("radians_s"),
+                    function("real(c_double) function", "radians_to_degrees_d"): parameters("radians_d")
+                }
+            }
+        }
+    }

--- a/testing/projects/cpp_func_overloads/__init__.py
+++ b/testing/projects/cpp_func_overloads/__init__.py
@@ -1,0 +1,68 @@
+"""
+The ``cpp_func_overloads`` test project.
+"""
+
+from testing.hierarchies import directory, file, function, namespace, parameters
+
+
+def default_class_hierarchy_dict():
+    """Return the default class hierarchy dictionary."""
+    return {}
+
+
+def default_file_hierarchy_dict():
+    """Return the default file hierarchy dictionary."""
+    return {
+        directory("include"): {
+            directory("overload"): {
+                file("overload.hpp"): {
+                    function("int", "blargh"): parameters("int"),
+                    namespace("overload"): {
+                        # No args
+                        function("void", "blargh"): parameters(),
+                        # "pure" int overloads
+                        function("int", "blargh"): parameters("int"),
+                        function("int", "blargh"): parameters("int", "int"),
+                        function("int", "blargh"): parameters("int", "int", "int"),
+                        # "pure" float overloads
+                        function("float", "blargh"): parameters("float"),
+                        function("float", "blargh"): parameters("float", "float"),
+                        function("float", "blargh"): parameters("float", "float", "float"),
+                        # "pure" std::string overloads
+                        function("std::string", "blargh"): parameters("const std::string&"),
+                        function("std::string", "blargh"): parameters(
+                            "const std::string&", "const std::string&"
+                        ),
+                        function("std::string", "blargh"): parameters(
+                            "const std::string&", "const std::string&", "const std::string&"
+                        ),
+                        # absurd mixtures
+                        function("std::size_t", "blargh"): parameters("std::size_t", "const std::string&"),
+                        function("std::size_t", "blargh"): parameters(
+                            "std::size_t", "const float&", "double", "const std::string&"
+                        ),
+                        # vector overloads
+                        function("void", "blargh"): parameters("std::vector<std::string>&"),
+                        function("void", "blargh"): parameters("std::vector<std::vector<int>>&"),
+                        # pointer style (spaces matter...)
+                        function("void", "blargh"): parameters(
+                            "const float *", "const float *", "float *", "std::size_t"
+                        ),
+                        # templates
+                        function("C::type", "blargh", template=["class C"]): parameters("typename C::type"),
+                        # SFINAE is really pretty yeah?
+                        function(
+                            "std::enable_if<std::is_convertible<typename C::type, T>::value, T>::type",
+                            "blargh",
+                            template=["class C", "typename T"]
+                        ): parameters("typename C::type"),
+                        function(
+                            "std::enable_if<!std::is_convertible<typename C::type, T>::value, T>::type",
+                            "blargh",
+                            template=["class C", "typename T"]
+                        ): parameters("typename C::type")
+                    }
+                }
+            }
+        }
+    }

--- a/testing/projects/cpp_long_names/__init__.py
+++ b/testing/projects/cpp_long_names/__init__.py
@@ -1,0 +1,191 @@
+"""
+The ``cpp_long_names`` test project.
+"""
+
+import os
+import platform
+
+from testing import TEST_PROJECTS_ROOT
+from testing.hierarchies import                                                        \
+    clike, define, directory, enum, file, function, namespace, parameters, typedef,    \
+    union, variable
+
+
+RUN_ABSURD_TEST = platform.system() != "Windows"
+"""
+When ``platform.system() != "Windows"``, :data:`ABSURD_DIRECTORY_PATH` is created.
+"""
+
+
+def make_it_big(prefix):
+    """Mirrors the macro ``MAKE_IT_BIG`` in ``absurdly_long_names.hpp``."""
+    big = [
+        prefix, "that", "is", "longer", "than", "two", "hundred", "and", "fifty",
+        "five", "characters", "long", "which", "is", "an", "absolutely", "and",
+        "completely", "ridiculous", "thing", "to", "do", "and", "if", "you", "did",
+        "this", "in", "the", "real", "world", "you", "put", "yourself", "comfortably",
+        "in", "a", "position", "to", "be", "downsized", "and", "outta", "here", "as",
+        "soul", "position", "would", "explain", "to", "you"
+    ]
+    return "_".join(big)
+
+
+ABSURD_DIRECTORY_PATH = os.path.abspath(os.path.join(
+    TEST_PROJECTS_ROOT,
+    "cpp_long_names",
+    "include",
+    make_it_big("directory_structure").replace("_", os.sep)
+))
+"""
+The absurd directory path that will be created depending on :data:`RUN_ABSURD_TEST`.
+"""
+
+
+def default_class_hierarchy_dict():
+    """Return the default class hierarchy dictionary."""
+    return {}
+
+
+def default_file_hierarchy_dict():
+    """
+    Return the default file hierarchy dictionary.
+
+    If :data:`RUN_ABSURD_TEST` is ``True``, :data:`ABSURD_DIRECTORY_PATH` will be
+    incorporated in the returned dictionary.
+    """
+    absurdly_long_names_hpp_contents = {
+        define("MAKE_IT_BIG"): {},
+        clike("class", make_it_big("class")): {},
+        clike("struct", make_it_big("struct")): {},
+        function("std::string", make_it_big("function")): parameters(),
+        enum(make_it_big("enum")): {},  # TODO: values("first", "second", "third"),
+        namespace(make_it_big("namespace")): {
+            variable("int", "value"): {}
+        },
+        define(make_it_big("define").upper()): {},
+        variable("int", make_it_big("variable")): {},
+        typedef(make_it_big("typedef"), "float"): {},
+        union(make_it_big("union")): {}
+    }
+
+    if RUN_ABSURD_TEST:
+        absurd_directory_structure = {
+            directory("structure"): {
+                directory("that"): {
+                    directory("is"): {
+                        directory("longer"): {
+                            directory("than"): {
+                                directory("two"): {
+                                    directory("hundred"): {
+                                        directory("and"): {
+                                            directory("fifty"): {
+                                                directory("five"): {
+                                                    directory("characters"): {
+                                                        directory("long"): {
+                                                            directory("which"): {
+                                                                directory("is"): {
+                                                                    directory("an"): {
+                                                                        directory("absolutely"): {
+                                                                            directory("and"): {
+                                                                                directory("completely"): {
+                                                                                    directory("ridiculous"): {
+                                                                                        directory("thing"): {
+                                                                                            directory("to"): {
+                                                                                                directory("do"): {                                                                                                                                                                     # noqa: E501
+                                                                                                    directory("and"): {                                                                                                                                                                # noqa: E501
+                                                                                                        directory("if"): {                                                                                                                                                             # noqa: E501
+                                                                                                            directory("you"): {                                                                                                                                                        # noqa: E501
+                                                                                                                directory("did"): {                                                                                                                                                    # noqa: E501
+                                                                                                                    directory("this"): {                                                                                                                                               # noqa: E501
+                                                                                                                        directory("in"): {                                                                                                                                             # noqa: E501
+                                                                                                                            directory("the"): {                                                                                                                                        # noqa: E501
+                                                                                                                                directory("real"): {                                                                                                                                   # noqa: E501
+                                                                                                                                    directory("world"): {                                                                                                                              # noqa: E501
+                                                                                                                                        directory("you"): {                                                                                                                            # noqa: E501
+                                                                                                                                            directory("put"): {                                                                                                                        # noqa: E501
+                                                                                                                                                directory("yourself"): {                                                                                                               # noqa: E501
+                                                                                                                                                    directory("comfortably"): {                                                                                                        # noqa: E501
+                                                                                                                                                        directory("in"): {                                                                                                             # noqa: E501
+                                                                                                                                                            directory("a"): {                                                                                                          # noqa: E501
+                                                                                                                                                                directory("position"): {                                                                                               # noqa: E501
+                                                                                                                                                                    directory("to"): {                                                                                                 # noqa: E501
+                                                                                                                                                                        directory("be"): {                                                                                             # noqa: E501
+                                                                                                                                                                            directory("downsized"): {                                                                                  # noqa: E501
+                                                                                                                                                                                directory("and"): {                                                                                    # noqa: E501
+                                                                                                                                                                                    directory("outta"): {                                                                              # noqa: E501
+                                                                                                                                                                                        directory("here"): {                                                                           # noqa: E501
+                                                                                                                                                                                            directory("as"): {                                                                         # noqa: E501
+                                                                                                                                                                                                directory("soul"): {                                                                   # noqa: E501
+                                                                                                                                                                                                    directory("position"): {                                                           # noqa: E501
+                                                                                                                                                                                                        directory("would"): {                                                          # noqa: E501
+                                                                                                                                                                                                            directory("explain"): {                                                    # noqa: E501
+                                                                                                                                                                                                                directory("to"): {                                                     # noqa: E501
+                                                                                                                                                                                                                    directory("you"): {                                                # noqa: E501
+                                                                                                                                                                                                                        file("a_file.hpp"): {                                          # noqa: E501
+                                                                                                                                                                                                                            function("std::string", "extremely_nested"): parameters()  # noqa: E501
+                                                                                                                                                                                                                        }                                                              # noqa: E501
+                                                                                                                                                                                                                    }                                                                  # noqa: E501
+                                                                                                                                                                                                                }                                                                      # noqa: E501
+                                                                                                                                                                                                            }                                                                          # noqa: E501
+                                                                                                                                                                                                        }                                                                              # noqa: E501
+                                                                                                                                                                                                    }                                                                                  # noqa: E501
+                                                                                                                                                                                                }                                                                                      # noqa: E501
+                                                                                                                                                                                            }                                                                                          # noqa: E501
+                                                                                                                                                                                        }                                                                                              # noqa: E501
+                                                                                                                                                                                    }                                                                                                  # noqa: E501
+                                                                                                                                                                                }                                                                                                      # noqa: E501
+                                                                                                                                                                            }                                                                                                          # noqa: E501
+                                                                                                                                                                        }                                                                                                              # noqa: E501
+                                                                                                                                                                    }                                                                                                                  # noqa: E501
+                                                                                                                                                                }                                                                                                                      # noqa: E501
+                                                                                                                                                            }                                                                                                                          # noqa: E501
+                                                                                                                                                        }                                                                                                                              # noqa: E501
+                                                                                                                                                    }                                                                                                                                  # noqa: E501
+                                                                                                                                                }                                                                                                                                      # noqa: E501
+                                                                                                                                            }                                                                                                                                          # noqa: E501
+                                                                                                                                        }                                                                                                                                              # noqa: E501
+                                                                                                                                    }                                                                                                                                                  # noqa: E501
+                                                                                                                                }                                                                                                                                                      # noqa: E501
+                                                                                                                            }                                                                                                                                                          # noqa: E501
+                                                                                                                        }                                                                                                                                                              # noqa: E501
+                                                                                                                    }                                                                                                                                                                  # noqa: E501
+                                                                                                                }                                                                                                                                                                      # noqa: E501
+                                                                                                            }
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+                                                                                            }
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return {
+            directory("include"): {
+                file("absurdly_long_names.hpp"): absurdly_long_names_hpp_contents,
+                directory("directory"): absurd_directory_structure
+            }
+        }
+    else:
+        return {
+            directory("include"): {
+                file("absurdly_long_names.hpp"): absurdly_long_names_hpp_contents
+            }
+        }

--- a/testing/projects/cpp_nesting/__init__.py
+++ b/testing/projects/cpp_nesting/__init__.py
@@ -1,0 +1,101 @@
+"""
+The ``cpp_nesting`` test project.
+"""
+
+from testing.hierarchies import clike, directory, file, namespace, union
+
+
+def default_class_hierarchy_dict():
+    """Return the default class hierarchy dictionary."""
+    return {
+        clike("struct", "top_level"): {},
+        namespace("nested"): {
+            clike("struct", "one"): {
+                clike("struct", "params"): {
+                    union("four_bytes"): {}
+                }
+            },
+            clike("struct", "two"): {
+                clike("struct", "params"): {
+                    union("four_bytes"): {}
+                }
+            },
+            union("four_bytes"): {},
+            namespace("dual_nested"): {
+                clike("struct", "one"): {
+                    clike("struct", "params"): {
+                        union("four_bytes"): {}
+                    }
+                },
+                clike("struct", "two"): {
+                    clike("struct", "params"): {
+                        union("four_bytes"): {}
+                    }
+                }
+            }
+        }
+    }
+
+
+def default_file_hierarchy_dict():
+    """Return the default file hierarchy dictionary."""
+    return {
+        directory("include"): {
+            file("top_level.hpp"): {
+                clike("struct", "top_level"): {}
+            },
+            directory("nested"): {
+                directory("one"): {
+                    file("one.hpp"): {
+                        namespace("nested"): {
+                            clike("struct", "one"): {
+                                clike("struct", "params"): {
+                                    union("four_bytes"): {}
+                                }
+                            }
+                        }
+                    },
+                },
+                directory("two"): {
+                    file("two.hpp"): {
+                        namespace("nested"): {
+                            clike("struct", "two"): {
+                                clike("struct", "params"): {
+                                    union("four_bytes"): {}
+                                }
+                            },
+                            union("four_bytes"): {}
+                        }
+                    }
+                },
+                directory("dual_nested"): {
+                    directory("one"): {
+                        file("one.hpp"): {
+                            namespace("nested"): {
+                                namespace("dual_nested"): {
+                                    clike("struct", "one"): {
+                                        clike("struct", "params"): {
+                                            union("four_bytes"): {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    directory("two"): {
+                        file("two.hpp"): {
+                            namespace("nested"): {
+                                namespace("dual_nested"): {
+                                    clike("struct", "two"): {
+                                        clike("struct", "params"): {
+                                            union("four_bytes"): {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }

--- a/testing/projects/cpp_pimpl/__init__.py
+++ b/testing/projects/cpp_pimpl/__init__.py
@@ -1,0 +1,59 @@
+"""
+The ``cpp_pimpl`` test project.
+"""
+
+from testing.hierarchies import clike, directory, file, namespace
+
+
+def default_class_hierarchy_dict():
+    """Return the default class hierarchy dictionary."""
+    return {
+        namespace("pimpl"): {
+            clike("class", "Planet"): {},
+            clike("class", "Earth"): {},
+            clike("class", "EarthImpl"): {},
+            clike("class", "Earth_v2"): {},
+            clike("class", "Jupiter"): {},
+            clike("class", "JupiterImpl"): {},
+            clike("class", "Jupiter_v2"): {},
+            namespace("detail"): {
+                clike("class", "EarthImpl"): {},
+                clike("class", "JupiterImpl"): {}
+            }
+        }
+    }
+
+
+def default_file_hierarchy_dict():
+    """Return the default file hierarchy dictionary."""
+    return {
+        directory("include"): {
+            directory("pimpl"): {
+                file("planet.hpp"): {
+                    namespace("pimpl"): {
+                        clike("class", "Planet"): {}
+                    }
+                },
+                file("earth.hpp"): {
+                    namespace("pimpl"): {
+                        clike("class", "Earth"): {},
+                        clike("class", "EarthImpl"): {},
+                        clike("class", "Earth_v2"): {},
+                        namespace("detail"): {
+                            clike("class", "EarthImpl"): {}
+                        }
+                    }
+                },
+                file("jupiter.hpp"): {
+                    namespace("pimpl"): {
+                        clike("class", "Jupiter"): {},
+                        clike("class", "JupiterImpl"): {},
+                        clike("class", "Jupiter_v2"): {},
+                        namespace("detail"): {
+                            clike("class", "JupiterImpl"): {}
+                        }
+                    }
+                }
+            }
+        }
+    }

--- a/testing/tests/c_maths.py
+++ b/testing/tests/c_maths.py
@@ -14,9 +14,8 @@ import os
 
 from testing.base import ExhaleTestCase
 from testing.decorators import confoverrides, no_run
-from testing.hierarchies import                                       \
-    class_hierarchy, compare_class_hierarchy, compare_file_hierarchy, \
-    directory, file, file_hierarchy, function, parameters
+from testing.hierarchies import                                                        \
+    class_hierarchy, compare_class_hierarchy, compare_file_hierarchy, file_hierarchy
 
 
 class CMathsTests(ExhaleTestCase):
@@ -36,17 +35,8 @@ class CMathsTests(ExhaleTestCase):
 
     def test_hierarchies(self):
         """Verify the class and file hierarchies."""
-        # verify the file hierarchy and file declaration relationships
-        file_hierarchy_dict = {
-            directory("include"): {
-                file("c_maths.h"): {
-                    function("int", "cm_add"): parameters("int", "int"),
-                    function("int", "cm_sub"): parameters("int", "int")
-                }
-            }
-        }
-        compare_file_hierarchy(self, file_hierarchy(file_hierarchy_dict))
-        compare_class_hierarchy(self, class_hierarchy({}))
+        compare_class_hierarchy(self, class_hierarchy(self.class_hierarchy_dict()))
+        compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict()))
 
 
 @no_run

--- a/testing/tests/configs_tree_view.py
+++ b/testing/tests/configs_tree_view.py
@@ -11,14 +11,14 @@ Tests specifically focused on the various tree view configurations.
 from __future__ import unicode_literals
 import os
 import re
-import textwrap
+from textwrap import dedent
 
 from testing.base import ExhaleTestCase
 from testing.decorators import confoverrides
 
 
 class_hierarchy_ground_truth = {
-    "default_rst_list": textwrap.dedent(r'''
+    "default_rst_list": dedent(r'''
         - :ref:`namespace_nested`
             - :ref:`namespace_nested__dual_nested`
                 - :ref:`exhale_struct_structnested_1_1dual__nested_1_1one`
@@ -36,7 +36,7 @@ class_hierarchy_ground_truth = {
             - :ref:`exhale_union_unionnested_1_1four__bytes`
         - :ref:`exhale_struct_structtop__level`
     '''),
-    "collapsible_lists": textwrap.dedent(r'''
+    "collapsible_lists": dedent(r'''
         <ul class="treeView" id="class-treeView">
         <li>
             <ul class="collapsibleList">
@@ -101,7 +101,7 @@ class_hierarchy_ground_truth = {
         </li><!-- only tree view element -->
         </ul><!-- /treeView class-treeView -->
     '''),  # noqa: E501
-    "bootstrap": textwrap.dedent(r'''
+    "bootstrap": dedent(r'''
         <div id="class-treeView"></div>
         <script type="text/javascript">
         function getClassHierarchyTree() {
@@ -254,7 +254,7 @@ Keys and what they represent:
 
 
 file_hierarchy_ground_truth = {
-    "default_rst_list": textwrap.dedent(r'''
+    "default_rst_list": dedent(r'''
         - :ref:`dir_include`
             - :ref:`dir_include_nested`
                 - :ref:`dir_include_nested_dual_nested`
@@ -268,7 +268,7 @@ file_hierarchy_ground_truth = {
                     - :ref:`file_include_nested_two_two.hpp`
             - :ref:`file_include_top_level.hpp`
     '''),
-    "collapsible_lists": textwrap.dedent(r'''
+    "collapsible_lists": dedent(r'''
         <ul class="treeView" id="file-treeView">
         <li>
             <ul class="collapsibleList">
@@ -317,7 +317,7 @@ file_hierarchy_ground_truth = {
         </li><!-- only tree view element -->
         </ul><!-- /treeView file-treeView -->
     '''),  # noqa: E501
-    "bootstrap": textwrap.dedent(r'''
+    "bootstrap": dedent(r'''
         <div id="file-treeView"></div>
         <script type="text/javascript">
         function getFileHierarchyTree() {
@@ -673,12 +673,26 @@ class TreeViewHierarchyTests(ExhaleTestCase):
         """
         Verify the default reStructuredText list appears as expected.
         """
+        err_fmt = dedent("""\
+            Expected
+            ============================================================================
+            {expected}
+
+            Got
+            ============================================================================
+            {got}
+        """)
         test_class_view, test_file_view = self.raw_hierarchies()
+
+        class_default = class_hierarchy_ground_truth["default_rst_list"]
         self.assertTrue(
-            class_hierarchy_ground_truth["default_rst_list"] in test_class_view
-        )
+            class_default in test_class_view,
+            err_fmt.format(expected=class_default, got=test_class_view))
+
+        file_default = file_hierarchy_ground_truth["default_rst_list"]
         self.assertTrue(
-            file_hierarchy_ground_truth["default_rst_list"] in test_file_view
+            file_default in test_file_view,
+            err_fmt.format(expected=file_default, got=test_file_view)
         )
 
     @confoverrides(exhale_args={

--- a/testing/tests/cpp_fortran_mixed.py
+++ b/testing/tests/cpp_fortran_mixed.py
@@ -17,9 +17,7 @@ import re
 from testing import get_exhale_root
 from testing.base import ExhaleTestCase
 from testing.decorators import confoverrides
-from testing.hierarchies import                                                   \
-    compare_file_hierarchy, directory, file, file_hierarchy, function, namespace, \
-    parameters, variable
+from testing.hierarchies import compare_file_hierarchy, file_hierarchy
 
 
 @confoverrides(exhale_args={
@@ -56,37 +54,6 @@ class CPPFortranMixed(ExhaleTestCase):
     test_project = "cpp_fortran_mixed"
     """.. testproject:: cpp_fortran_mixed"""
 
-    file_hierarchy_dict = {
-        directory("include"): {
-            directory("convert"): {
-                file("convert.hpp"): {
-                    namespace("convert"): {
-                        function("T", "to_degrees", template=["typename T"]): parameters("T"),
-                        function("T", "to_radians", template=["typename T"]): parameters("T")
-                    }
-                }
-            }
-        },
-        directory("src"): {
-            file("conversions.f90"): {
-                namespace("conversions"): {
-                    variable("real(c_float)", "pi_s"): {},
-                    variable("real(c_double)", "pi_d"): {},
-                    variable("real(c_float)", "s_180"): {},
-                    variable("real(c_double)", "d_180"): {},
-                    # NOTE: function parameters in fortran are a little weird.
-                    # 1. <type> has 'function', e.g. 'real(c_float) function'
-                    # 2. Parameters are names, not types?
-                    function("real(c_float) function", "degrees_to_radians_s"): parameters("degrees_s"),
-                    function("real(c_double) function", "degrees_to_radians_d"): parameters("degrees_d"),
-                    function("real(c_float) function", "radians_to_degrees_s"): parameters("radians_s"),
-                    function("real(c_double) function", "radians_to_degrees_d"): parameters("radians_d")
-                }
-            }
-        }
-    }
-    """The file hierarchy for this project."""
-
     def test_hierarchies(self):
         """
         Validate the class and file hierarchies.
@@ -103,8 +70,8 @@ class CPPFortranMixed(ExhaleTestCase):
             the ``cpp_nesting`` project).
         """
         if platform.system() != "Windows":
-            compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict))
             # compare_class_hierarchy(self, class_hierarchy({}))
+            compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict()))
 
     def validate_pygments_lexers(self, exhale_root, node_map):
         """

--- a/testing/tests/cpp_func_overloads.py
+++ b/testing/tests/cpp_func_overloads.py
@@ -13,8 +13,7 @@ from __future__ import unicode_literals
 
 from testing.base import ExhaleTestCase
 from testing.decorators import no_cleanup
-from testing.hierarchies import \
-    compare_file_hierarchy, directory, file, file_hierarchy, function, namespace, parameters
+from testing.hierarchies import compare_file_hierarchy, file_hierarchy
 
 
 class CPPFuncOverloads(ExhaleTestCase):
@@ -25,61 +24,6 @@ class CPPFuncOverloads(ExhaleTestCase):
     test_project = "cpp_func_overloads"
     """.. testproject:: cpp_func_overloads"""
 
-    file_hierarchy_dict = {
-        directory("include"): {
-            directory("overload"): {
-                file("overload.hpp"): {
-                    function("int", "blargh"): parameters("int"),
-                    namespace("overload"): {
-                        # No args
-                        function("void", "blargh"): parameters(),
-                        # "pure" int overloads
-                        function("int", "blargh"): parameters("int"),
-                        function("int", "blargh"): parameters("int", "int"),
-                        function("int", "blargh"): parameters("int", "int", "int"),
-                        # "pure" float overloads
-                        function("float", "blargh"): parameters("float"),
-                        function("float", "blargh"): parameters("float", "float"),
-                        function("float", "blargh"): parameters("float", "float", "float"),
-                        # "pure" std::string overloads
-                        function("std::string", "blargh"): parameters("const std::string&"),
-                        function("std::string", "blargh"): parameters(
-                            "const std::string&", "const std::string&"
-                        ),
-                        function("std::string", "blargh"): parameters(
-                            "const std::string&", "const std::string&", "const std::string&"
-                        ),
-                        # absurd mixtures
-                        function("std::size_t", "blargh"): parameters("std::size_t", "const std::string&"),
-                        function("std::size_t", "blargh"): parameters(
-                            "std::size_t", "const float&", "double", "const std::string&"
-                        ),
-                        # vector overloads
-                        function("void", "blargh"): parameters("std::vector<std::string>&"),
-                        function("void", "blargh"): parameters("std::vector<std::vector<int>>&"),
-                        # pointer style (spaces matter...)
-                        function("void", "blargh"): parameters(
-                            "const float *", "const float *", "float *", "std::size_t"
-                        ),
-                        # templates
-                        function("C::type", "blargh", template=["class C"]): parameters("typename C::type"),
-                        # SFINAE is really pretty yeah?
-                        function(
-                            "std::enable_if<std::is_convertible<typename C::type, T>::value, T>::type",
-                            "blargh",
-                            template=["class C", "typename T"]
-                        ): parameters("typename C::type"),
-                        function(
-                            "std::enable_if<!std::is_convertible<typename C::type, T>::value, T>::type",
-                            "blargh",
-                            template=["class C", "typename T"]
-                        ): parameters("typename C::type")
-                    }
-                }
-            }
-        }
-    }
-
     @no_cleanup
     def test_builds(self):
         """Test deliberately kept to serve as a perpetual reminder this is still broken."""
@@ -87,4 +31,4 @@ class CPPFuncOverloads(ExhaleTestCase):
 
     def test_file_hierarchy(self):
         """Verify the file hierarchy."""
-        compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict))
+        compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict()))

--- a/testing/tests/cpp_long_names.py
+++ b/testing/tests/cpp_long_names.py
@@ -22,191 +22,18 @@ import pytest
 
 from testing import TEST_PROJECTS_ROOT
 from testing.base import ExhaleTestCase
-from testing.hierarchies import                                                   \
-    clike, compare_file_hierarchy, define, directory, enum, file, file_hierarchy, \
-    function, namespace, parameters, typedef, union, variable
-
-
-RUN_ABSURD_TEST = platform.system() != "Windows"
-"""
-When ``platform.system() != "Windows"``, :data:`ABSURD_DIRECTORY_PATH` is created.
-"""
-
-
-def make_it_big(prefix):
-    """Mirrors the macro ``MAKE_IT_BIG`` in ``absurdly_long_names.hpp``."""
-    big = [
-        prefix, "that", "is", "longer", "than", "two", "hundred", "and", "fifty",
-        "five", "characters", "long", "which", "is", "an", "absolutely", "and",
-        "completely", "ridiculous", "thing", "to", "do", "and", "if", "you", "did",
-        "this", "in", "the", "real", "world", "you", "put", "yourself", "comfortably",
-        "in", "a", "position", "to", "be", "downsized", "and", "outta", "here", "as",
-        "soul", "position", "would", "explain", "to", "you"
-    ]
-    return "_".join(big)
-
-
-ABSURD_DIRECTORY_PATH = os.path.abspath(os.path.join(
-    TEST_PROJECTS_ROOT,
-    "cpp_long_names",
-    "include",
-    make_it_big("directory_structure").replace("_", os.sep)
-))
-"""
-The absurd directory path that will be created depending on :data:`RUN_ABSURD_TEST`.
-"""
-
-
-def make_file_hierarchy_dict():
-    """
-    Return the :class:`python:dict` representing the file hierarchy.
-
-    If :data:`RUN_ABSURD_TEST` is ``True``, :data:`ABSURD_DIRECTORY_PATH` will be
-    incorporated in the returned dictionary.
-    """
-    absurdly_long_names_hpp_contents = {
-        define("MAKE_IT_BIG"): {},
-        clike("class", make_it_big("class")): {},
-        clike("struct", make_it_big("struct")): {},
-        function("std::string", make_it_big("function")): parameters(),
-        enum(make_it_big("enum")): {},  # TODO: values("first", "second", "third"),
-        namespace(make_it_big("namespace")): {
-            variable("int", "value"): {}
-        },
-        define(make_it_big("define").upper()): {},
-        variable("int", make_it_big("variable")): {},
-        typedef(make_it_big("typedef"), "float"): {},
-        union(make_it_big("union")): {}
-    }
-
-    if RUN_ABSURD_TEST:
-        absurd_directory_structure = {
-            directory("structure"): {
-                directory("that"): {
-                    directory("is"): {
-                        directory("longer"): {
-                            directory("than"): {
-                                directory("two"): {
-                                    directory("hundred"): {
-                                        directory("and"): {
-                                            directory("fifty"): {
-                                                directory("five"): {
-                                                    directory("characters"): {
-                                                        directory("long"): {
-                                                            directory("which"): {
-                                                                directory("is"): {
-                                                                    directory("an"): {
-                                                                        directory("absolutely"): {
-                                                                            directory("and"): {
-                                                                                directory("completely"): {
-                                                                                    directory("ridiculous"): {
-                                                                                        directory("thing"): {
-                                                                                            directory("to"): {
-                                                                                                directory("do"): {                                                                                                                                                                     # noqa: E501
-                                                                                                    directory("and"): {                                                                                                                                                                # noqa: E501
-                                                                                                        directory("if"): {                                                                                                                                                             # noqa: E501
-                                                                                                            directory("you"): {                                                                                                                                                        # noqa: E501
-                                                                                                                directory("did"): {                                                                                                                                                    # noqa: E501
-                                                                                                                    directory("this"): {                                                                                                                                               # noqa: E501
-                                                                                                                        directory("in"): {                                                                                                                                             # noqa: E501
-                                                                                                                            directory("the"): {                                                                                                                                        # noqa: E501
-                                                                                                                                directory("real"): {                                                                                                                                   # noqa: E501
-                                                                                                                                    directory("world"): {                                                                                                                              # noqa: E501
-                                                                                                                                        directory("you"): {                                                                                                                            # noqa: E501
-                                                                                                                                            directory("put"): {                                                                                                                        # noqa: E501
-                                                                                                                                                directory("yourself"): {                                                                                                               # noqa: E501
-                                                                                                                                                    directory("comfortably"): {                                                                                                        # noqa: E501
-                                                                                                                                                        directory("in"): {                                                                                                             # noqa: E501
-                                                                                                                                                            directory("a"): {                                                                                                          # noqa: E501
-                                                                                                                                                                directory("position"): {                                                                                               # noqa: E501
-                                                                                                                                                                    directory("to"): {                                                                                                 # noqa: E501
-                                                                                                                                                                        directory("be"): {                                                                                             # noqa: E501
-                                                                                                                                                                            directory("downsized"): {                                                                                  # noqa: E501
-                                                                                                                                                                                directory("and"): {                                                                                    # noqa: E501
-                                                                                                                                                                                    directory("outta"): {                                                                              # noqa: E501
-                                                                                                                                                                                        directory("here"): {                                                                           # noqa: E501
-                                                                                                                                                                                            directory("as"): {                                                                         # noqa: E501
-                                                                                                                                                                                                directory("soul"): {                                                                   # noqa: E501
-                                                                                                                                                                                                    directory("position"): {                                                           # noqa: E501
-                                                                                                                                                                                                        directory("would"): {                                                          # noqa: E501
-                                                                                                                                                                                                            directory("explain"): {                                                    # noqa: E501
-                                                                                                                                                                                                                directory("to"): {                                                     # noqa: E501
-                                                                                                                                                                                                                    directory("you"): {                                                # noqa: E501
-                                                                                                                                                                                                                        file("a_file.hpp"): {                                          # noqa: E501
-                                                                                                                                                                                                                            function("std::string", "extremely_nested"): parameters()  # noqa: E501
-                                                                                                                                                                                                                        }                                                              # noqa: E501
-                                                                                                                                                                                                                    }                                                                  # noqa: E501
-                                                                                                                                                                                                                }                                                                      # noqa: E501
-                                                                                                                                                                                                            }                                                                          # noqa: E501
-                                                                                                                                                                                                        }                                                                              # noqa: E501
-                                                                                                                                                                                                    }                                                                                  # noqa: E501
-                                                                                                                                                                                                }                                                                                      # noqa: E501
-                                                                                                                                                                                            }                                                                                          # noqa: E501
-                                                                                                                                                                                        }                                                                                              # noqa: E501
-                                                                                                                                                                                    }                                                                                                  # noqa: E501
-                                                                                                                                                                                }                                                                                                      # noqa: E501
-                                                                                                                                                                            }                                                                                                          # noqa: E501
-                                                                                                                                                                        }                                                                                                              # noqa: E501
-                                                                                                                                                                    }                                                                                                                  # noqa: E501
-                                                                                                                                                                }                                                                                                                      # noqa: E501
-                                                                                                                                                            }                                                                                                                          # noqa: E501
-                                                                                                                                                        }                                                                                                                              # noqa: E501
-                                                                                                                                                    }                                                                                                                                  # noqa: E501
-                                                                                                                                                }                                                                                                                                      # noqa: E501
-                                                                                                                                            }                                                                                                                                          # noqa: E501
-                                                                                                                                        }                                                                                                                                              # noqa: E501
-                                                                                                                                    }                                                                                                                                                  # noqa: E501
-                                                                                                                                }                                                                                                                                                      # noqa: E501
-                                                                                                                            }                                                                                                                                                          # noqa: E501
-                                                                                                                        }                                                                                                                                                              # noqa: E501
-                                                                                                                    }                                                                                                                                                                  # noqa: E501
-                                                                                                                }                                                                                                                                                                      # noqa: E501
-                                                                                                            }
-                                                                                                        }
-                                                                                                    }
-                                                                                                }
-                                                                                            }
-                                                                                        }
-                                                                                    }
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return {
-            directory("include"): {
-                file("absurdly_long_names.hpp"): absurdly_long_names_hpp_contents,
-                directory("directory"): absurd_directory_structure
-            }
-        }
-    else:
-        return {
-            directory("include"): {
-                file("absurdly_long_names.hpp"): absurdly_long_names_hpp_contents
-            }
-        }
+from testing.hierarchies import compare_file_hierarchy, file_hierarchy
+from testing.projects.cpp_long_names import \
+    ABSURD_DIRECTORY_PATH, RUN_ABSURD_TEST, make_it_big
 
 
 def create_absurd_directory_structure():
     """
-    Create the absurd directory structure when :data:`RUN_ABSURD_TEST` is ``True``.
+    Create the absurd directory structure when |RUN_ABSURD_TEST| is ``True``.
 
     Helper function for the testing fixture :func:`potentially_with_insanity_fixture`.
+
+    .. |RUN_ABSURD_TEST| replace:: :data:`testing.projects.cpp_long_names.RUN_ABSURD_TEST`
     """
     if RUN_ABSURD_TEST:
         try:
@@ -241,19 +68,20 @@ def create_absurd_directory_structure():
 
 def remove_absurd_directory_structure():
     """
-    Remove the absurd directory structure when :data:`RUN_ABSURD_TEST` is ``True``.
+    Remove the absurd directory structure when |RUN_ABSURD_TEST| is ``True``.
 
     Helper function for the testing fixture :func:`potentially_with_insanity_fixture`.
     """
     if RUN_ABSURD_TEST:
+        absurd_dir_root = os.path.abspath(os.path.join(
+            TEST_PROJECTS_ROOT,
+            "cpp_long_names",
+            "include",
+            "directory"
+        ))
         try:
-            absurd_dir_root = os.path.abspath(os.path.join(
-                TEST_PROJECTS_ROOT,
-                "cpp_long_names",
-                "include",
-                "directory"
-            ))
-            shutil.rmtree(absurd_dir_root)
+            if os.path.isdir(absurd_dir_root):
+                shutil.rmtree(absurd_dir_root)
         except Exception as e:
             raise RuntimeError("Could not remove the directory [{0}]: {1}".format(
                 absurd_dir_root, e
@@ -266,7 +94,7 @@ def potentially_with_insanity_fixture():
     Class-level fixture that may create / remove the absurd directory.
 
     This will create the absurd directory structure before any tests are run, and
-    remove it when all are finished when :data:`RUN_ABSURD_TEST` is ``True``.
+    remove it when all are finished when |RUN_ABSURD_TEST| is ``True``.
     """
     create_absurd_directory_structure()
     yield
@@ -299,9 +127,6 @@ class CPPLongNames(ExhaleTestCase):
 
     test_project = "cpp_long_names"
     """.. testproject:: cpp_long_names"""
-
-    file_hierarchy_dict = make_file_hierarchy_dict()
-    """The (potentially absurd) file hierarchy for this project."""
 
     def test_hashes(self):
         """Verify the long names get hashed to the expected values."""
@@ -405,4 +230,4 @@ class CPPLongNames(ExhaleTestCase):
         so is rather pointless, and the added complexity to do so given the
         conditionally created structure is not worth the effort.
         """
-        compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict))
+        compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict()))

--- a/testing/tests/cpp_nesting.py
+++ b/testing/tests/cpp_nesting.py
@@ -13,9 +13,8 @@ from __future__ import unicode_literals
 
 from testing.base import ExhaleTestCase
 from testing.decorators import confoverrides
-from testing.hierarchies import                                              \
-    class_hierarchy, clike, compare_class_hierarchy, compare_file_hierarchy, \
-    directory, file, file_hierarchy, namespace, union
+from testing.hierarchies import                                                        \
+    class_hierarchy, compare_class_hierarchy, compare_file_hierarchy, file_hierarchy
 
 
 class CPPNesting(ExhaleTestCase):
@@ -26,114 +25,21 @@ class CPPNesting(ExhaleTestCase):
     test_project = "cpp_nesting"
     """.. testproject:: cpp_nesting"""
 
-    file_hierarchy_dict = {
-        directory("include"): {
-            file("top_level.hpp"): {
-                clike("struct", "top_level"): {}
-            },
-            directory("nested"): {
-                directory("one"): {
-                    file("one.hpp"): {
-                        namespace("nested"): {
-                            clike("struct", "one"): {
-                                clike("struct", "params"): {
-                                    union("four_bytes"): {}
-                                }
-                            }
-                        }
-                    },
-                },
-                directory("two"): {
-                    file("two.hpp"): {
-                        namespace("nested"): {
-                            clike("struct", "two"): {
-                                clike("struct", "params"): {
-                                    union("four_bytes"): {}
-                                }
-                            },
-                            union("four_bytes"): {}
-                        }
-                    }
-                },
-                directory("dual_nested"): {
-                    directory("one"): {
-                        file("one.hpp"): {
-                            namespace("nested"): {
-                                namespace("dual_nested"): {
-                                    clike("struct", "one"): {
-                                        clike("struct", "params"): {
-                                            union("four_bytes"): {}
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    directory("two"): {
-                        file("two.hpp"): {
-                            namespace("nested"): {
-                                namespace("dual_nested"): {
-                                    clike("struct", "two"): {
-                                        clike("struct", "params"): {
-                                            union("four_bytes"): {}
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-            }
-        }
-    }
-
-    class_hierarchy_dict = {
-        clike("struct", "top_level"): {},
-        namespace("nested"): {
-            clike("struct", "one"): {
-                clike("struct", "params"): {
-                    union("four_bytes"): {}
-                }
-            },
-            clike("struct", "two"): {
-                clike("struct", "params"): {
-                    union("four_bytes"): {}
-                }
-            },
-            union("four_bytes"): {},
-            namespace("dual_nested"): {
-                clike("struct", "one"): {
-                    clike("struct", "params"): {
-                        union("four_bytes"): {}
-                    }
-                },
-                clike("struct", "two"): {
-                    clike("struct", "params"): {
-                        union("four_bytes"): {}
-                    }
-                }
-            }
-        }
-    }
-
     def test_hierarchies(self):
         """Verify the class and file hierarchies."""
-        compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict))
-        compare_class_hierarchy(self, class_hierarchy(self.class_hierarchy_dict))
+        compare_class_hierarchy(self, class_hierarchy(self.class_hierarchy_dict()))
+        compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict()))
 
     @confoverrides(exhale_args={"doxygenStripFromPath": "../include"})
     def test_hierarchies_stripped(self):
         """
         Verify the class and file hierarchies with ``doxygenStripFromPath=../include``.
-
-        .. todo:: this test is not supported yet
         """
-        return  # TODO: Exhale should remove the include/ directory
+        compare_class_hierarchy(self, class_hierarchy(self.class_hierarchy_dict()))
         # dirty hack to pop off the first include/ directory without needing to know
         # the actual object that is the first and only key
-        for key in self.file_hierarchy_dict:
-            no_include = self.file_hierarchy_dict[key]
+        file_hierarchy_dict = self.file_hierarchy_dict()
+        for key in file_hierarchy_dict:
+            no_include = file_hierarchy_dict[key]
             break
         compare_file_hierarchy(self, file_hierarchy(no_include))
-        compare_class_hierarchy(self, class_hierarchy(self.class_hierarchy_dict))

--- a/testing/tests/cpp_pimpl.py
+++ b/testing/tests/cpp_pimpl.py
@@ -18,9 +18,8 @@ import textwrap
 from testing import get_exhale_root
 from testing.base import ExhaleTestCase
 from testing.decorators import confoverrides
-from testing.hierarchies import                                              \
-    class_hierarchy, clike, compare_class_hierarchy, compare_file_hierarchy, \
-    directory, file, file_hierarchy, namespace
+from testing.hierarchies import                                                        \
+    class_hierarchy, compare_class_hierarchy, compare_file_hierarchy, file_hierarchy
 
 
 class TestedExclusionTypes(object):
@@ -47,56 +46,6 @@ class CPPPimpl(ExhaleTestCase):
 
     test_project = "cpp_pimpl"
     """.. testproject:: cpp_pimpl"""
-
-    file_hierarchy_dict = {
-        directory("include"): {
-            directory("pimpl"): {
-                file("planet.hpp"): {
-                    namespace("pimpl"): {
-                        clike("class", "Planet"): {}
-                    }
-                },
-                file("earth.hpp"): {
-                    namespace("pimpl"): {
-                        clike("class", "Earth"): {},
-                        clike("class", "EarthImpl"): {},
-                        clike("class", "Earth_v2"): {},
-                        namespace("detail"): {
-                            clike("class", "EarthImpl"): {}
-                        }
-                    }
-                },
-                file("jupiter.hpp"): {
-                    namespace("pimpl"): {
-                        clike("class", "Jupiter"): {},
-                        clike("class", "JupiterImpl"): {},
-                        clike("class", "Jupiter_v2"): {},
-                        namespace("detail"): {
-                            clike("class", "JupiterImpl"): {}
-                        }
-                    }
-                }
-            }
-        }
-    }
-    """The file hierarchy for this test."""
-
-    class_hierarchy_dict = {
-        namespace("pimpl"): {
-            clike("class", "Planet"): {},
-            clike("class", "Earth"): {},
-            clike("class", "EarthImpl"): {},
-            clike("class", "Earth_v2"): {},
-            clike("class", "Jupiter"): {},
-            clike("class", "JupiterImpl"): {},
-            clike("class", "Jupiter_v2"): {},
-            namespace("detail"): {
-                clike("class", "EarthImpl"): {},
-                clike("class", "JupiterImpl"): {}
-            }
-        }
-    }
-    """The class hierarchy for this test."""
 
     def impl_link_names(self):
         """Link names for ``pimpl::{Earth,Jupiter}Impl``."""
@@ -403,8 +352,8 @@ class CPPPimpl(ExhaleTestCase):
 
     def test_hierarchies(self):
         """Verify the class and file hierarchies."""
-        compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict))
-        compare_class_hierarchy(self, class_hierarchy(self.class_hierarchy_dict))
+        compare_class_hierarchy(self, class_hierarchy(self.class_hierarchy_dict()))
+        compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict()))
 
     # TODO: once config objects are in this override is not necessary, but currently
     #       the tests in tests/configs.py populate a listingExclude....

--- a/testing/tests/cpp_with_spaces.py
+++ b/testing/tests/cpp_with_spaces.py
@@ -13,8 +13,7 @@ from __future__ import unicode_literals
 
 from testing.base import ExhaleTestCase
 from testing.decorators import no_cleanup
-from testing.hierarchies import compare_file_hierarchy, directory, file, \
-    file_hierarchy, function, namespace, parameters
+from testing.hierarchies import compare_file_hierarchy, file_hierarchy
 
 
 class CPPWithSpaces(ExhaleTestCase):
@@ -24,19 +23,6 @@ class CPPWithSpaces(ExhaleTestCase):
 
     test_project = "cpp with spaces"
     """.. testproject:: cpp with spaces"""
-
-    file_hierarchy_dict = {
-        directory("include"): {
-            directory("with spaces"): {
-                file("with spaces.hpp"): {
-                    namespace("with_spaces"): {
-                        function("int", "value"): parameters()
-                    }
-                }
-            }
-        }
-    }
-    """The file hierarchy for this project."""
 
     def test_hierarchies(self):
         """
@@ -48,7 +34,7 @@ class CPPWithSpaces(ExhaleTestCase):
             framework **as well as** stop emitting a "Class Hierarchy" on the root api
             page when it is empty.
         """
-        compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict))
+        compare_file_hierarchy(self, file_hierarchy(self.file_hierarchy_dict()))
 
     @no_cleanup
     def test_build(self):

--- a/tox.ini
+++ b/tox.ini
@@ -12,15 +12,15 @@ skip_install = true
 deps =
     sphinx{env:SPHINX_VERSION:}
     breathe{env:BREATHE_VERSION:}
-    bs4
+    beautifulsoup4
     lxml
     six
 commands =
     {envpython} -m pip install -q -r requirements-dev.txt
+    {envpython} -c 'import sphinx; print("\033[36;1mSphinx version: %s\033[0m" % sphinx.__version__)'
+    {envpython} -c 'import breathe; print("\033[36;1mBreathe version: %s\033[0m" % breathe.__version__)'
+    {envpython} -c 'import sys; print("\033[36;1mPython version: %d.%d.%d\033[0m" % sys.version_info[0:3])'
     pytest . {posargs}
-    {envpython} -c 'import sphinx; print("Tested against Sphinx version %s." % sphinx.__version__)'
-    {envpython} -c 'import breathe; print("Tested against Breathe version %s." % breathe.__version__)'
-    {envpython} -c 'import sys; print("Tested against Python version %d.%d.%d." % sys.version_info[0:3])'
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
- each testing/projects/{project} is dynamically imported
    - provides definitions for expected class / file hierarchies
    - hierarchies are deep copied, tests that reuse previously
      mutated these
    - docs updated to use automodule, except `cpp with spaces`
      (not possible to document in sphinx)
- ignore `from collections import MutableMapping` warnings
  (see also #119)
- skip mac builds on CI until #122 is solved
- install correct beautiful soup package in tox.ini
- fix url parsing in docs/testproject.py

These should never have been cluttered into #114...