### PR TITLE
enable parallel builds with sphinx

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,7 +12,7 @@ v0.2.4
 
 - Use the correct PyPI name ``beautifulsoup4`` rather than ``bs4`` (:pr:`120`).
 - Fix deprecated ``MutableMapping`` import for python 3.10 support (:pr:`124`).
-- Enable parallel builds (use the right ``setup`` function...) (:pr:`125`).
+- Enable parallel builds (use the right ``setup`` function...) (:pr:`126`).
 
 v0.2.3
 ----------------------------------------------------------------------------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,7 @@ v0.2.4
 
 - Use the correct PyPI name ``beautifulsoup4`` rather than ``bs4`` (:pr:`120`).
 - Fix deprecated ``MutableMapping`` import for python 3.10 support (:pr:`124`).
+- Enable parallel builds (use the right ``setup`` function...) (:pr:`125`).
 
 v0.2.3
 ----------------------------------------------------------------------------------------

--- a/exhale/__init__.py
+++ b/exhale/__init__.py
@@ -43,4 +43,10 @@ def setup(app):
     app.connect("builder-inited", environment_ready)
     # app.connect("env-purge-doc", cleanup_files)
 
-    return {"version": __version__}
+    return {
+        "version": __version__,
+        # Because Exhale hooks into / generates *BEFORE* any reading or writing occurs,
+        # it is parallel safe by default.
+        "parallel_read_safe": True,
+        "parallel_write_safe": True
+    }

--- a/setup.py
+++ b/setup.py
@@ -133,10 +133,6 @@ setup(
     include_package_data=True,
     # Because we are including non-python data files, it cannot be compressed
     zip_safe=False,
-    # Because Exhale hooks into / generates *BEFORE* any reading or writing occurs, it
-    # is parallel safe by default
-    parallel_read_safe=True,
-    parallel_write_safe=True,
     # Metadata for PyPI
     author="Stephen McDowell",
     author_email="exhale.hosted@gmail.com",


### PR DESCRIPTION
Before (just building the `exhale-companion` with `pip install sphinx` then `pip install exhale` (order mattered again, because of #120 I think, vanilla `pip install exhale` fails :cry:):

```console
$ sphinx-build -j 4 -b html -vv . _build &> output.txt
$ python -c 'import exhale; print(exhale.__version__)'
0.2.3
$ grep WARNING output.txt | grep -i parallel
WARNING: the exhale extension does not declare if it is safe for parallel reading, assuming it isn't - please ask the extension author to check and make it explicit
```

Now doing `pip install -e [this branch]`

```console
$  sphinx-build -j 4 -b html -vv . _build &> output.txt
$  python -c 'import exhale; print(exhale.__version__)'
0.2.4.dev
$ grep WARNING output.txt | grep -i parallel
```