### PR TITLE
pin lxml>=4.6.4 for windows dev convenience

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     # breathe{env:BREATHE_VERSION:}
     beautifulsoup4
     # NOTE: for dev convenience, see https://github.com/svenevs/exhale/issues/131
-    lxml>=4.7.0
+    lxml>=4.6.4
     six
     # testing requirements
     # NOTE: see .github/actions/testing_projects.yaml, updates here need to go there.

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,8 @@ deps =
     # TODO: waiting on breathe>=4.32.0 release
     # breathe{env:BREATHE_VERSION:}
     beautifulsoup4
-    lxml
+    # NOTE: for dev convenience, see https://github.com/svenevs/exhale/issues/131
+    lxml>=4.7.0
     six
     # testing requirements
     # NOTE: see .github/actions/testing_projects.yaml, updates here need to go there.


### PR DESCRIPTION
Fixes #131.

~~4.7.0 not on PyPI yet, they're currently preparing the release.  Will re-run this after they do.~~