### PR TITLE
Fix the parsing of the git remote.

### DIFF
--- a/docs/testproject.py
+++ b/docs/testproject.py
@@ -60,7 +60,7 @@ def get_projects_baseurl():
         user = https_match.groups()[0]
 
     # SSH url:   git@github.com:svenevs/exhale.git
-    ssh_re   = r"git@github\.com:(.*)/exhale\.git"
+    ssh_re   = r"git@github\.com:(.*)/exhale(\.git)?"
     ssh_match = re.match(ssh_re, git_remote_out)
     if ssh_match:
         user = ssh_match.groups()[0]


### PR DESCRIPTION
When cloning a GitHub repository with ssh, the URL may be either:

git@github.com:user/repo

or:

git@github.com:user/repo.git

This PR makes it so either is allowed.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>