### PR TITLE
avoid duplicate label warnings for .. include::'ed files 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,8 @@ v0.3.0
 
 - Do not write source files for empty hierarchies (:pr:`134`).
 - Support specialized template functions (:pr:`117`).
+- Prevent sphinx from processing files that are incorporated via a ``.. include::``
+  directive by renaming them to ``.rst.include`` suffix (:pr:`136`).
 
 v0.2.4
 ----------------------------------------------------------------------------------------

--- a/docs/reference/configs.rst
+++ b/docs/reference/configs.rst
@@ -157,7 +157,7 @@ that you will link to from your documentation is laid out as follows:
    .. note::
 
       This is performed by an ``.. include::`` directive.  The file for this section
-      is ``"{containmentFolder}/page_view_hierarchy.rst"``.
+      is ``"{containmentFolder}/page_view_hierarchy.rst.include"``.
 
    .. tip::
 
@@ -171,7 +171,7 @@ that you will link to from your documentation is laid out as follows:
    .. note::
 
       This is performed by an ``.. include::`` directive.  The file for this section
-      is ``"{containmentFolder}/class_view_hierarchy.rst"``.
+      is ``"{containmentFolder}/class_view_hierarchy.rst.include"``.
 
 5. Next, the File Hierarchy is included.  By default this is a bulleted list; see the
    :ref:`usage_creating_the_treeview` section.
@@ -179,7 +179,7 @@ that you will link to from your documentation is laid out as follows:
    .. note::
 
       This is performed by an ``.. include::`` directive.  The file for this section
-      is ``"{containmentFolder}/file_view_hierarchy.rst"``.
+      is ``"{containmentFolder}/file_view_hierarchy.rst.include"``.
 
 6. If provided, the value of the key ``"afterHierarchyDescription"`` given to
    ``exhale_args`` will be included.  See
@@ -197,7 +197,7 @@ that you will link to from your documentation is laid out as follows:
    .. note::
 
       This is performed by an ``.. include::`` directive.  The file for this section
-      is ``"{containmentFolder}/unabridged_api.rst"``.
+      is ``"{containmentFolder}/unabridged_api.rst.include"``.
 
    .. tip::
 

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -2856,10 +2856,7 @@ class ExhaleRoot(object):
                 ########################################################################
                 # Page header / linking.                                               #
                 ########################################################################
-                # Generate a link label for every generated file except for the indexpage.
-                # Sphinx doesn't like it when a page is included but also has the same
-                # link label at the top of the file.  Since the indexpage will be
-                # included later on (see generateAPIRootBody), just skip the label.
+                # generate a link label for every generated file
                 if node.refid == "indexpage":
                     link_declaration = ""
                 else:

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -2857,10 +2857,7 @@ class ExhaleRoot(object):
                 # Page header / linking.                                               #
                 ########################################################################
                 # generate a link label for every generated file
-                if node.refid == "indexpage":
-                    link_declaration = ""
-                else:
-                    link_declaration = ".. _{0}:".format(node.link_name)
+                link_declaration = ".. _{0}:".format(node.link_name)
 
                 # Add the metadata if they requested it
                 if configs.pageLevelConfigMeta:

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -2857,7 +2857,10 @@ class ExhaleRoot(object):
                 # Page header / linking.                                               #
                 ########################################################################
                 # generate a link label for every generated file
-                link_declaration = ".. _{0}:".format(node.link_name)
+                if node.refid == "indexpage":
+                    link_declaration = ""
+                else:
+                    link_declaration = ".. _{0}:".format(node.link_name)
 
                 # Add the metadata if they requested it
                 if configs.pageLevelConfigMeta:

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -2856,7 +2856,10 @@ class ExhaleRoot(object):
                 ########################################################################
                 # Page header / linking.                                               #
                 ########################################################################
-                # generate a link label for every generated file
+                # Generate a link label for every generated file except for the indexpage.
+                # Sphinx doesn't like it when a page is included but also has the same
+                # link label at the top of the file.  Since the indexpage will be
+                # included later on (see generateAPIRootBody), just skip the label.
                 if node.refid == "indexpage":
                     link_declaration = ""
                 else:

--- a/testing/base.py
+++ b/testing/base.py
@@ -483,7 +483,7 @@ class ExhaleTestCase(unittest.TestCase):
         # build path to unabridged api document that adds all toctree directives
         root = get_exhale_root(self)
         containmentFolder = self.getAbsContainmentFolder()
-        unabridged_api_path = os.path.join(containmentFolder, "unabridged_api.rst")
+        unabridged_api_path = os.path.join(containmentFolder, "unabridged_api.rst.include")
         unabridged_orphan_path = os.path.join(containmentFolder, "unabridged_orphan.rst")
 
         # gather lines that match the indented part of the toctree
@@ -569,7 +569,7 @@ class ExhaleTestCase(unittest.TestCase):
             "Mismatch: doxygen_mainpage_was_used != index_include!")
 
         include_map = {
-            "page_index.rst": index_include,
+            "page_index.rst.include": index_include,
             os.path.basename(root.page_hierarchy_file): page_hierarchy_include,
             os.path.basename(root.class_hierarchy_file): class_hierarchy_include,
             os.path.basename(root.file_hierarchy_file): file_hierarchy_include,

--- a/testing/tests/configs_tree_view.py
+++ b/testing/tests/configs_tree_view.py
@@ -461,16 +461,18 @@ class TreeViewHierarchyTests(ExhaleTestCase):
     """
 
     def class_view_hierarchy_file(self):
-        """Path to ``class_view_hierarchy.rst`` for this test."""
-        return os.path.join(self.getAbsContainmentFolder(), "class_view_hierarchy.rst")
+        """Path to ``class_view_hierarchy.rst.include`` for this test."""
+        return os.path.join(
+            self.getAbsContainmentFolder(), "class_view_hierarchy.rst.include")
 
     def file_view_hierarchy_file(self):
-        """Path to ``file_view_hierarchy.rst`` for this test."""
-        return os.path.join(self.getAbsContainmentFolder(), "file_view_hierarchy.rst")
+        """Path to ``file_view_hierarchy.rst.include`` for this test."""
+        return os.path.join(
+            self.getAbsContainmentFolder(), "file_view_hierarchy.rst.include")
 
     def raw_hierarchies(self):
         """
-        Raw contents of ``class_view_hierarchy.rst`` and ``file_view_hierarchy.rst``.
+        Raw contents of ``{class,file}_view_hierarchy.rst.include``.
 
         **Return** (Length ``2`` :class:`python:tuple` of :class:`python:str`)
             The string contents of ``(class_view, file_view)``, in that order.
@@ -500,7 +502,7 @@ class TreeViewHierarchyTests(ExhaleTestCase):
 
     def html_hierarchies(self):
         """
-        Hierarchy text from ``class_view_hierarchy.rst`` and ``file_view_hierarchy.rst``.
+        Hierarchy text from ``{class,file}_view_hierarchy.rst``.
 
         When ``createTreeView=True``, the generated page has something like:
 

--- a/testing/tests/cpp_pimpl.py
+++ b/testing/tests/cpp_pimpl.py
@@ -252,7 +252,7 @@ class CPPPimpl(ExhaleTestCase):
             The exclusion that is currently being tested.
         """
         class_hierarchy_path = os.path.join(
-            self.getAbsContainmentFolder(), "class_view_hierarchy.rst"
+            self.getAbsContainmentFolder(), "class_view_hierarchy.rst.include"
         )
         expected_class_hierarchy = self.expected_class_hierarchy(exclusions)
         with open(class_hierarchy_path) as class_hierarchy:


### PR DESCRIPTION
Sphinx does not like it when a file that is later included
(via .. include directive) has the very same link label inside of
it.  To avoid a Sphinx warning, skip link label generation for
the pageindex.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>