### PR TITLE
WIP c++ attributes and function templates project

### DIFF
--- a/docs/testing/projects.rst
+++ b/docs/testing/projects.rst
@@ -42,6 +42,12 @@ complete its import.
 .. automodule:: testing.projects.cpp_dir_underscores
    :members:
 
+``testing.projects.cpp_meta`` Project
+----------------------------------------------------------------------------------------
+
+.. automodule:: testing.projects.cpp_meta
+   :members:
+
 ``testing.projects.cpp_nesting`` Project
 ----------------------------------------------------------------------------------------
 

--- a/testing/projects/CMakeLists.txt
+++ b/testing/projects/CMakeLists.txt
@@ -27,7 +27,7 @@ project(exhale-projects)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_BUILD_TYPE "Debug") # required for code coverage
@@ -119,6 +119,7 @@ set(EXHALE_PROJECTS
   cpp_func_overloads
   cpp_long_names
   cpp_dir_underscores
+  cpp_meta
   cpp_nesting
   cpp_pimpl
   "cpp with spaces"

--- a/testing/projects/CMakeLists.txt
+++ b/testing/projects/CMakeLists.txt
@@ -191,3 +191,21 @@ elseif (MSVC)
     DEPENDS exhale-projects-unit-tests
   )
 endif()
+
+# One of the above clears out compile flags which is an issue, we want to
+# disable some intentional warnings coming out of cpp_meta project.
+#     warning: 'carries_dependency' attribute directive ignored [-Wattributes]
+#     warning: maybe_unused attribute ignored [-Wattributes]
+#     warning: 'meta::deprecated::ground_truth is deprecated [-Wdeprecated-declarations]
+include(CheckCXXCompilerFlag)
+foreach (flag -Wno-attributes -Wno-deprecated-declarations)
+  check_cxx_compiler_flag(${flag} has_flag)
+  if (has_flag)
+    set_property(
+      SOURCE
+        ${CMAKE_CURRENT_SOURCE_DIR}/cpp_meta/src/tests.cpp
+      APPEND
+      PROPERTY
+        COMPILE_OPTIONS ${flag})
+  endif()
+endforeach()

--- a/testing/projects/cpp_meta/CMakeLists.txt
+++ b/testing/projects/cpp_meta/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This file is dedicated to the public domain.  If your jurisdiction requires a        #
 # specific license:                                                                    #
 #                                                                                      #
-# Copyright (c) Stephen McDowell, 2017-2021                                            #
+# Copyright (c) Stephen McDowell, 2017-2022                                            #
 # License:      CC0 1.0 Universal                                                      #
 # License Text: https://creativecommons.org/publicdomain/zero/1.0/legalcode            #
 ########################################################################################

--- a/testing/projects/cpp_meta/CMakeLists.txt
+++ b/testing/projects/cpp_meta/CMakeLists.txt
@@ -15,15 +15,11 @@ target_sources(exhale-projects-unit-tests
     ${CMAKE_CURRENT_SOURCE_DIR}/src/tests.cpp
 )
 
-# Ignore some warnings e.g. intentional use of [[ deprecated ]] things.
-# TODO: not sure how to disable... flag isn't found.
-# warning: ‘bool meta::deprecated::this_is_fine()’ is deprecated [-Wdeprecated-declarations]
-# include(CheckCXXCompilerFlag)
-# check_cxx_compiler_flag("-Wdeprecated-declarations" no_deprecated)
-
 target_include_directories(exhale-projects-tests-interface
   INTERFACE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 add_open_cpp_coverage_source_dirs(include src)
+
+# NOTE: see bottom of parent CMakeLists.txt for excluding intentional warnings.

--- a/testing/projects/cpp_meta/CMakeLists.txt
+++ b/testing/projects/cpp_meta/CMakeLists.txt
@@ -1,0 +1,29 @@
+########################################################################################
+# This file is dedicated to the public domain.  If your jurisdiction requires a        #
+# specific license:                                                                    #
+#                                                                                      #
+# Copyright (c) Stephen McDowell, 2017-2021                                            #
+# License:      CC0 1.0 Universal                                                      #
+# License Text: https://creativecommons.org/publicdomain/zero/1.0/legalcode            #
+########################################################################################
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+project(cpp-meta LANGUAGES CXX)
+
+# "Header only library": add tests and include the directory
+target_sources(exhale-projects-unit-tests
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tests.cpp
+)
+
+# Ignore some warnings e.g. intentional use of [[ deprecated ]] things.
+# TODO: not sure how to disable... flag isn't found.
+# warning: ‘bool meta::deprecated::this_is_fine()’ is deprecated [-Wdeprecated-declarations]
+# include(CheckCXXCompilerFlag)
+# check_cxx_compiler_flag("-Wdeprecated-declarations" no_deprecated)
+
+target_include_directories(exhale-projects-tests-interface
+  INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+add_open_cpp_coverage_source_dirs(include src)

--- a/testing/projects/cpp_meta/__init__.py
+++ b/testing/projects/cpp_meta/__init__.py
@@ -1,0 +1,31 @@
+"""
+The ``cpp_meta`` test project.
+"""
+
+from testing.hierarchies import directory, file, function, parameters, namespace
+
+
+def default_class_hierarchy_dict():
+    """Return the default class hierarchy dictionary."""
+    return {}
+
+
+def default_file_hierarchy_dict():
+    """Return the default file hierarchy dictionary."""
+    raise NotImplementedError("TODO... match the cxx tests when completed.")
+    return {
+        directory("include"): {
+            directory("meta"): {
+                file("cxx_attrs.hpp"): {
+                    namespace("meta"): {
+                        function(): parameters(),
+                    }
+                },
+                file("tfuncs.hpp"): {
+                    namespace("meta"): {
+                        function(): parameters(),
+                    }
+                }
+            }
+        }
+    }

--- a/testing/projects/cpp_meta/include/meta/cxx_attrs.hpp
+++ b/testing/projects/cpp_meta/include/meta/cxx_attrs.hpp
@@ -1,0 +1,124 @@
+/***************************************************************************************
+ * This file is dedicated to the public domain.  If your jurisdiction requires a       *
+ * specific license:                                                                   *
+ *                                                                                     *
+ * Copyright (c) Stephen McDowell, 2017-2021                                           *
+ * License:      CC0 1.0 Universal                                                     *
+ * License Text: https://creativecommons.org/publicdomain/zero/1.0/legalcode           *
+ **************************************************************************************/
+/**
+ * \file
+ *
+ * \brief Various signatures with c++ attributes involved.
+ *
+ * See: https://en.cppreference.com/w/cpp/language/attributes
+ *
+ * Skipped as irrelevant for documentation tests:
+ *
+ * - fallthrough
+ * - likely
+ * - unlikely
+ */
+#pragma once
+
+/// The metaphysical nature of a namespace.
+namespace meta {
+    /// Encapsulates `[[ noreturn ]]`.
+    namespace noreturn {
+        /// From: https://en.cppreference.com/w/cpp/language/attributes/noreturn
+        [[ noreturn ]] void f() {
+            throw "f() must throw";
+        }
+
+        /// From: https://en.cppreference.com/w/cpp/language/attributes/noreturn
+        /// Testing `[[ noreturn ]]`` on the other side.
+        void q [[ noreturn ]] (int i) {
+            throw "q() throws unconditionally.";
+        }
+    }// namespace noreturn
+
+    /// Encapsulates `[[ carries_dependency ]]`.
+    namespace carries_dependency {
+        /// Option (1): on a parameter.
+        int carry([[ carries_dependency ]] int *me) { return me[0]; }
+
+        /// Option (2): on a function.
+        [[ carries_dependency ]] int* pass_through(int *me) { return me; }
+    }// namespace carries_dependency
+
+    /// Encapsulates `[[ deprecated ]]`.
+    namespace [[ deprecated ]] deprecated {
+        /// The ground truth of all things.
+        [[ deprecated ]] static constexpr int ground_truth = 0;
+
+        /// A deprecated struct.
+        struct [[ deprecated("this is fine") ]] ThisIs {
+            bool fine = true;///< It is ok.
+        };
+
+        /// A deprecated function.
+        [[ deprecated ]] bool this_is_fine() { return true; }
+    }// namespace deprecated
+
+    /// Encapsulates `[[ nodiscard ]]`.
+    namespace nodiscard {
+        /// A struct not to be discarded.
+        struct [[ nodiscard ]] PleaseDontKillMe {
+            int keep = 11;///< Keep it 11.
+        };
+
+        /// C++ 20 on a function.
+        /// From: https://en.cppreference.com/w/cpp/language/attributes/nodiscard
+        [[ nodiscard("PURE FUN") ]]
+        int strategic_value(int x, int y) { return x^y; }
+
+        /// On an enum.
+        enum [[ nodiscard ]] Keeper {
+            ForSomeTime = 0,///< Just for a little while.
+            ForLife = 1,///< It's starting to get serious.
+            ForEver = 2,///< You made a commitment.
+            ForEverAndEver = 3///< And you aren't getting out of it.
+
+        };
+    }// namespace nodiscard
+
+    /// Encapsulates `[[ maybe_unused ]]`.
+    /// See: https://en.cppreference.com/w/cpp/language/attributes/maybe_unused
+    namespace maybe_unused {
+        /// A maybe unused struct.
+        struct [[ maybe_unused ]] MayBe {
+            int unused = 666;///< It May Be Unused.
+        };
+
+        /// A maybe unused typedef.
+        [[ maybe_unused ]] typedef MayBe* MayBePtrTdef;
+
+        /// A maybe unused typdef as using statement.
+        using MayBePtrUsing = MayBe*;
+
+        /// A static "variable".
+        [[ maybe_unused ]] static constexpr int stat_var = 222;
+
+        /// A union.
+        union U {
+            [[ maybe_unused]] int n;///< May be unused.
+        };
+
+        /// On a function.
+        /// From: https://en.cppreference.com/w/cpp/language/attributes/maybe_unused
+        [[ maybe_unused ]] bool f([[ maybe_unused ]] bool thing1,
+                                  [[ maybe_unused ]] bool thing2) {
+            [[ maybe_unused ]] bool b = thing1 && thing2 || !(thing1 && thing2);
+            assert(b); // in release mode, assert is compiled out, and b is unused
+                       // no warning because it is declared [[maybe_unused]]
+            return true;
+        } // parameters thing1 and thing2 are not used, no warning
+
+        /// On an enum.
+        enum [[ maybe_unused ]] MayBeNum {
+            May [[ maybe_unused ]] = 0,///< May
+            Be = 1,///< Be
+            Num = 2///< Num
+        };
+    }// namespace maybe_unused
+}// namespace meta

--- a/testing/projects/cpp_meta/include/meta/cxx_attrs.hpp
+++ b/testing/projects/cpp_meta/include/meta/cxx_attrs.hpp
@@ -2,7 +2,7 @@
  * This file is dedicated to the public domain.  If your jurisdiction requires a       *
  * specific license:                                                                   *
  *                                                                                     *
- * Copyright (c) Stephen McDowell, 2017-2021                                           *
+ * Copyright (c) Stephen McDowell, 2017-2022                                           *
  * License:      CC0 1.0 Universal                                                     *
  * License Text: https://creativecommons.org/publicdomain/zero/1.0/legalcode           *
  **************************************************************************************/

--- a/testing/projects/cpp_meta/include/meta/tfuncs.hpp
+++ b/testing/projects/cpp_meta/include/meta/tfuncs.hpp
@@ -2,7 +2,7 @@
  * This file is dedicated to the public domain.  If your jurisdiction requires a       *
  * specific license:                                                                   *
  *                                                                                     *
- * Copyright (c) Stephen McDowell, 2017-2021                                           *
+ * Copyright (c) Stephen McDowell, 2017-2022                                           *
  * License:      CC0 1.0 Universal                                                     *
  * License Text: https://creativecommons.org/publicdomain/zero/1.0/legalcode           *
  **************************************************************************************/

--- a/testing/projects/cpp_meta/include/meta/tfuncs.hpp
+++ b/testing/projects/cpp_meta/include/meta/tfuncs.hpp
@@ -1,0 +1,8 @@
+/***************************************************************************************
+ * This file is dedicated to the public domain.  If your jurisdiction requires a       *
+ * specific license:                                                                   *
+ *                                                                                     *
+ * Copyright (c) Stephen McDowell, 2017-2021                                           *
+ * License:      CC0 1.0 Universal                                                     *
+ * License Text: https://creativecommons.org/publicdomain/zero/1.0/legalcode           *
+ **************************************************************************************/

--- a/testing/projects/cpp_meta/src/tests.cpp
+++ b/testing/projects/cpp_meta/src/tests.cpp
@@ -1,0 +1,82 @@
+/***************************************************************************************
+ * This file is dedicated to the public domain.  If your jurisdiction requires a       *
+ * specific license:                                                                   *
+ *                                                                                     *
+ * Copyright (c) Stephen McDowell, 2017-2021                                           *
+ * License:      CC0 1.0 Universal                                                     *
+ * License Text: https://creativecommons.org/publicdomain/zero/1.0/legalcode           *
+ **************************************************************************************/
+#include <catch2/catch.hpp>
+#include <meta/cxx_attrs.hpp>
+
+/* ================================================================================== */
+
+TEST_CASE( "[[ noreturn ]]", "[cpp-meta]" ) {
+    using namespace meta::noreturn;
+    REQUIRE_THROWS(f(), "f() must throw");
+    REQUIRE_THROWS(q(11), "q() throws unconditionally.");
+}
+
+/* ================================================================================== */
+
+TEST_CASE( "[[ carries_dependency ]]", "[cpp-meta]" ) {
+    using namespace meta::carries_dependency;
+    int me = 22;
+    REQUIRE(carry(&me) == 22);
+    me = 33;
+    REQUIRE(*pass_through(&me) == 33);
+}
+
+/* ================================================================================== */
+
+// TODO: probably should tell the compiler its OK we want to use it ;)
+TEST_CASE( "[[ deprecated ]]", "[cpp-meta]" ) {
+    using namespace meta::deprecated;
+    REQUIRE(ground_truth == 0);
+    ThisIs this_is;
+    REQUIRE(this_is.fine == true);
+    REQUIRE(this_is_fine() == true);
+}
+
+/* ================================================================================== */
+
+TEST_CASE( "[[ nodiscard ]]", "[cpp-meta]" ) {
+    using namespace meta::nodiscard;
+    PleaseDontKillMe pdkm;
+    REQUIRE(pdkm.keep == 11);
+    int sv = strategic_value(11, 33);
+    REQUIRE(sv == 42);
+    REQUIRE(Keeper::ForSomeTime == 0);
+    REQUIRE(Keeper::ForLife == 1);
+    REQUIRE(Keeper::ForEver == 2);
+    REQUIRE(Keeper::ForEverAndEver == 3);
+}
+
+/* ================================================================================== */
+
+TEST_CASE( "[[ maybe_unused ]]", "[cpp-meta]" ) {
+    using namespace meta::maybe_unused;
+    MayBe may_be;
+    REQUIRE(may_be.unused == 666);
+
+    may_be.unused = 777;
+    MayBePtrTdef mb_ptr_tdef = &may_be;
+    REQUIRE(mb_ptr_tdef->unused == 777);
+    may_be.unused = 1111;
+    MayBePtrUsing mb_ptr_use = &may_be;
+    REQUIRE(mb_ptr_use->unused == 1111);
+
+    REQUIRE(stat_var == 222);
+
+    U u{1221};
+    REQUIRE(u.n == 1221);
+
+    REQUIRE(f(true, true) == true);
+    REQUIRE(f(true, false) == true);
+    REQUIRE(f(false, true) == true);
+    REQUIRE(f(false, false) == true);
+
+    REQUIRE(MayBeNum::May == 0);
+    REQUIRE(MayBeNum::Be == 1);
+    REQUIRE(MayBeNum::Num == 2);
+}

--- a/testing/projects/cpp_meta/src/tests.cpp
+++ b/testing/projects/cpp_meta/src/tests.cpp
@@ -2,7 +2,7 @@
  * This file is dedicated to the public domain.  If your jurisdiction requires a       *
  * specific license:                                                                   *
  *                                                                                     *
- * Copyright (c) Stephen McDowell, 2017-2021                                           *
+ * Copyright (c) Stephen McDowell, 2017-2022                                           *
  * License:      CC0 1.0 Universal                                                     *
  * License Text: https://creativecommons.org/publicdomain/zero/1.0/legalcode           *
  **************************************************************************************/


### PR DESCRIPTION
New testing project being added for c++ attributes and any known gotchas with c++ templates (TBD).  Objective is help identify where the breakages are for #106, figure out what has been fixed with #117, and iron out what does or does not need to be given to breathe vs what needs to be removed.  Especially where functions are concerned.

- [ ] Add the python tests.
    - [ ] Get `cpp_meta/__init__.py` in order.
- [ ] [Attributes]() are almost finished being added to the C++ code.  Needs:
    - [ ] [`no_unique_address`](https://en.cppreference.com/w/cpp/language/attributes/no_unique_address)
    - [ ] [`optimized_for_synchronized`](https://en.cppreference.com/w/cpp/language/attributes/optimize_for_synchronized) -- AFAICT we can get away with lots of warnings in `meta/cxx_attrs.hpp` and just ignore them.
- [ ] Template functions (not to be confused with function overload test project, which is related but separate).  :
    - [ ] Add function templates using `T*` so there is a test case for #129 string escaping.
    - [ ] Probably some `&` and `&&` stuff.
- [ ] `noexcept`, other (?) specifiers #113 
- [ ] Functions with macros in signatures https://github.com/svenevs/exhale/issues/94#issuecomment-691034705 (can they be handled or should document to remove them?)
- [ ] Find out what does and does not need to be given to breathe vs what needs to be removed.  Once and for all?

If anyone has functions or template functions with wonky metaprogramming or other things that exhale currently chokes on, and would like to donate them, please leave a comment or issue a PR to this branch:

- License for the `meta/tfuncs.hpp` (terrible functions) file is CC0:
    - Do not contribute code you don't have a right to.
    - Update the license author names, comma separated, alphabetical by last name at the top of the file (if comment, just explain who owns it).

C++20 code: I have no idea where things are at with concepts and exhale, or breathe, or sphinx.  I think concepts are best left for a `meta/concepts.hpp` file and discussed in a different PR since I doubt they work.  Right now we're trying to get C++17 working... :no_mouth:
