### PR TITLE
revive support for the multiproject monkeypatch

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,8 @@ v0.3.0
 - Support specialized template functions (:pr:`117`).
 - Prevent sphinx from processing files that are incorporated via a ``.. include::``
   directive by renaming them to ``.rst.include`` suffix (:pr:`136`).
+- Add ``:project: {app.config.breathe_default_project}`` to every breathe directive
+  to make the monkeypatch (:issue:`27`) work (:pr:`139`).
 
 v0.2.4
 ----------------------------------------------------------------------------------------

--- a/exhale/utils.py
+++ b/exhale/utils.py
@@ -555,15 +555,23 @@ def specificationsForKind(kind):
         The correctly formatted specifier(s) for the given ``kind``.  If no specifier(s)
         are necessary or desired, the empty string is returned.
     '''
+    # TODO: this is to support the monkeypatch
+    # https://github.com/svenevs/exhale/issues/27
+    ret = []
+
     # use the custom directives function
     if configs.customSpecificationsMapping:
-        return configs.customSpecificationsMapping[kind]
+        ret = configs.customSpecificationsMapping[kind]
 
     # otherwise, just provide class and struct
     if kind == "class" or kind == "struct":
-        return [":members:", ":protected-members:", ":undoc-members:"]
+        ret = [":members:", ":protected-members:", ":undoc-members:"]
 
-    return []  # use breathe defaults
+    # the monkeypatch re-configures breathe_default_project each time which was
+    # foolishly relied on elsewhere and undoing that blunder requires undoing
+    # all of the shenanigans that is configs.py...
+    ret.insert(0, ":project: " + configs._the_app.config.breathe_default_project)
+    return ret
 
 
 class AnsiColors:

--- a/testing/tests/cpp_nesting.py
+++ b/testing/tests/cpp_nesting.py
@@ -17,7 +17,7 @@ from textwrap import dedent
 from exhale.utils import heading_mark
 
 from testing.base import ExhaleTestCase
-from testing.decorators import confoverrides
+from testing.decorators import confoverrides, no_cleanup
 from testing.hierarchies import                                                        \
     class_hierarchy, compare_class_hierarchy, compare_file_hierarchy, file,            \
     file_hierarchy
@@ -229,3 +229,20 @@ class CPPNestingPages(ExhaleTestCase):
         """)
         with open(self.app.exhale_root.page_hierarchy_file, "r") as phf:
             assert expected_page_hierarchy in phf.read()
+
+    @no_cleanup
+    @confoverrides(exhale_args={
+        "rootFileTitle": "",
+        "exhaleDoxygenStdin": dedent("""\
+            INPUT            = ../include
+            EXCLUDE_PATTERNS = */page_town_rock_alt.hpp
+        """)})
+    def test_html_output(self):
+        """
+        Verify exhale builds a project.
+
+        This is not really a test.  But it can be helpful to view a test project build,
+        in the ``testing/projects/cpp_nesting`` folder you can open
+        ``docs_CPPNestingPages_test_html_output/_build/html/index.html`` to view.
+        """
+        self.app.build()


### PR DESCRIPTION
Take advantage of the utils.specificationsForKind returning any possible default or customSpecificationsForKind by user being used to manufacture every directive to also stuff in

    :project: {app.config.breathe_default_project}

Refs: #27

@florianhumblot I did some local testing and this doesn't appear to break the status quo for exhale's (unfortunate) single-project-only builds.  Are you able to test this and see if it works for you with multiproject and the monkeypatch?  It's definitely a hack but well, I'm OK with using a hack to support a hack :upside_down_face:  As noted in the comment in the diff, multiproject support "properly" effectively requires a rewrite of this whole darn thing.  One day...

    pip install git+https://github.com/svenevs/exhale.git@fix/multiproj-monkeypatch

That will install this branch (which will get deleted once it merges) :slightly_smiling_face: