### PR TITLE
Revert "revive support for the multiproject monkeypatch (#139)"

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,8 +12,6 @@ v0.3.0
 - Support specialized template functions (:pr:`117`).
 - Prevent sphinx from processing files that are incorporated via a ``.. include::``
   directive by renaming them to ``.rst.include`` suffix (:pr:`136`).
-- Add ``:project: {app.config.breathe_default_project}`` to every breathe directive
-  to make the monkeypatch (:issue:`27`) work (:pr:`139`).
 
 v0.2.4
 ----------------------------------------------------------------------------------------

--- a/exhale/utils.py
+++ b/exhale/utils.py
@@ -555,23 +555,15 @@ def specificationsForKind(kind):
         The correctly formatted specifier(s) for the given ``kind``.  If no specifier(s)
         are necessary or desired, the empty string is returned.
     '''
-    # TODO: this is to support the monkeypatch
-    # https://github.com/svenevs/exhale/issues/27
-    ret = []
-
     # use the custom directives function
     if configs.customSpecificationsMapping:
-        ret = configs.customSpecificationsMapping[kind]
+        return configs.customSpecificationsMapping[kind]
 
     # otherwise, just provide class and struct
     if kind == "class" or kind == "struct":
-        ret = [":members:", ":protected-members:", ":undoc-members:"]
+        return [":members:", ":protected-members:", ":undoc-members:"]
 
-    # the monkeypatch re-configures breathe_default_project each time which was
-    # foolishly relied on elsewhere and undoing that blunder requires undoing
-    # all of the shenanigans that is configs.py...
-    ret.insert(0, ":project: " + configs._the_app.config.breathe_default_project)
-    return ret
+    return []  # use breathe defaults
 
 
 class AnsiColors:

--- a/testing/tests/cpp_nesting.py
+++ b/testing/tests/cpp_nesting.py
@@ -17,7 +17,7 @@ from textwrap import dedent
 from exhale.utils import heading_mark
 
 from testing.base import ExhaleTestCase
-from testing.decorators import confoverrides, no_cleanup
+from testing.decorators import confoverrides
 from testing.hierarchies import                                                        \
     class_hierarchy, compare_class_hierarchy, compare_file_hierarchy, file,            \
     file_hierarchy
@@ -229,20 +229,3 @@ class CPPNestingPages(ExhaleTestCase):
         """)
         with open(self.app.exhale_root.page_hierarchy_file, "r") as phf:
             assert expected_page_hierarchy in phf.read()
-
-    @no_cleanup
-    @confoverrides(exhale_args={
-        "rootFileTitle": "",
-        "exhaleDoxygenStdin": dedent("""\
-            INPUT            = ../include
-            EXCLUDE_PATTERNS = */page_town_rock_alt.hpp
-        """)})
-    def test_html_output(self):
-        """
-        Verify exhale builds a project.
-
-        This is not really a test.  But it can be helpful to view a test project build,
-        in the ``testing/projects/cpp_nesting`` folder you can open
-        ``docs_CPPNestingPages_test_html_output/_build/html/index.html`` to view.
-        """
-        self.app.build()


### PR DESCRIPTION
This reverts commit bd5fcd70984da676ea348f9c140189508483a65b.

The monkey patching is causing a lot of problems in our usage of exhale.  In particular, every single include directive is getting put into the output files multiple times, like this:

```
docs_build/rcl_lifecycle/rcl_lifecycle/default_sphinx_project/generated/define_visibility__control_8h_1a0767c60cb7b7851b1ff3fb00683fc13e.rst:13: WARNING: Error in "doxygendefine" directive:
invalid option data: duplicate option "project".

.. doxygendefine:: RCL_LIFECYCLE_PUBLIC_TYPE
   :project: rcl_lifecycle Doxygen Project
   :project: rcl_lifecycle Doxygen Project
   :project: rcl_lifecycle Doxygen Project
   :project: rcl_lifecycle Doxygen Project
   :project: rcl_lifecycle Doxygen Project
```

This PR somewhat controversially reverts the monkey-patching, getting us back to a state where things mostly work (I still have one other WARNING to chase down, but I'll do that separately).  @svenevs Thoughts on this?