### PR TITLE
Check if the hierarchy files exist before generating includes.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Changelog
 v0.3.0
 ----------------------------------------------------------------------------------------
 
-- Do not write source files for empty hierarchies (:pr:`134`).
+- Do not write source files for empty hierarchies (:pr:`134`, :pr:`147`).
 - Support specialized template functions (:pr:`117`).
 - Prevent sphinx from processing files that are incorporated via a ``.. include::``
   directive by renaming them to ``.rst.include`` suffix (:pr:`136`).

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -3535,17 +3535,20 @@ class ExhaleRoot(object):
                         break
                 # Include the page, class, and file hierarchies
                 if any(node.kind == "page" for node in self.all_nodes):
-                    generated_index.write(".. include:: {0}\n\n".format(
-                        os.path.basename(self.page_hierarchy_file)
-                    ))
+                    if os.path.exists(self.page_hierarchy_file):
+                        generated_index.write(".. include:: {0}\n\n".format(
+                            os.path.basename(self.page_hierarchy_file)
+                        ))
                 if any(node.kind in utils.CLASS_LIKE_KINDS for node in self.all_nodes):
-                    generated_index.write(".. include:: {0}\n\n".format(
-                        os.path.basename(self.class_hierarchy_file)
-                    ))
+                    if os.path.exists(self.class_hierarchy_file):
+                        generated_index.write(".. include:: {0}\n\n".format(
+                            os.path.basename(self.class_hierarchy_file)
+                        ))
                 if any(node.kind in {"dir", "file"} for node in self.all_nodes):
-                    generated_index.write(".. include:: {0}\n\n".format(
-                        os.path.basename(self.file_hierarchy_file)
-                    ))
+                    if os.path.exists(self.file_hierarchy_file):
+                        generated_index.write(".. include:: {0}\n\n".format(
+                            os.path.basename(self.file_hierarchy_file)
+                        ))
 
                 # Add the afterHierarchyDescription if provided
                 if configs.afterHierarchyDescription:

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -3534,21 +3534,18 @@ class ExhaleRoot(object):
                         ))
                         break
                 # Include the page, class, and file hierarchies
-                if any(node.kind == "page" for node in self.all_nodes):
-                    if os.path.exists(self.page_hierarchy_file):
-                        generated_index.write(".. include:: {0}\n\n".format(
-                            os.path.basename(self.page_hierarchy_file)
-                        ))
-                if any(node.kind in utils.CLASS_LIKE_KINDS for node in self.all_nodes):
-                    if os.path.exists(self.class_hierarchy_file):
-                        generated_index.write(".. include:: {0}\n\n".format(
-                            os.path.basename(self.class_hierarchy_file)
-                        ))
-                if any(node.kind in {"dir", "file"} for node in self.all_nodes):
-                    if os.path.exists(self.file_hierarchy_file):
-                        generated_index.write(".. include:: {0}\n\n".format(
-                            os.path.basename(self.file_hierarchy_file)
-                        ))
+                if os.path.exists(self.page_hierarchy_file):
+                    generated_index.write(".. include:: {0}\n\n".format(
+                        os.path.basename(self.page_hierarchy_file)
+                    ))
+                if os.path.exists(self.class_hierarchy_file):
+                    generated_index.write(".. include:: {0}\n\n".format(
+                        os.path.basename(self.class_hierarchy_file)
+                    ))
+                if os.path.exists(self.file_hierarchy_file):
+                    generated_index.write(".. include:: {0}\n\n".format(
+                        os.path.basename(self.file_hierarchy_file)
+                    ))
 
                 # Add the afterHierarchyDescription if provided
                 if configs.afterHierarchyDescription:


### PR DESCRIPTION
This reverts commit 0d1a8a832e7c2efe1f7766d501bd23a96f6f9f8a.

With this in place, I was getting errors of the kind:

```
docs_build/rcl_lifecycle/rcl_lifecycle/default_sphinx_project/generated/index.rst:3: CRITICAL: Problems with "include" directive path:
InputError: [Errno 2] No such file or directory: 'default_sphinx_project/generated/page_view_hierarchy.rst.include'.
```

That is, because `final_data_string` is empty, we were never creating `page_view_hiearchy.rst.include`, but we were still trying to `.. include` it.  Revert this patch, which seems to make things happier.  @roehling FYI.  @svenevs What do you think?