### PR TITLE
Prevent multiple project specification

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,7 @@ v0.3.0
 - Prevent sphinx from processing files that are incorporated via a ``.. include::``
   directive by renaming them to ``.rst.include`` suffix (:pr:`136`).
 - Add ``:project: {app.config.breathe_default_project}`` to every breathe directive
-  to make the monkeypatch (:issue:`27`) work (:pr:`139`).
+  to make the monkeypatch (:issue:`27`) work (:pr:`139`, :pr:`148`).
 - Do not require :data:`~exhale.configs.containmentFolder` to be a "direct"
   subdirectory of ``app.srcdir``, allow any arbitrary subdirectory (:pr:`144`).
 - Update how css and js are added using a dubious check into the sphinx internals before

--- a/exhale/utils.py
+++ b/exhale/utils.py
@@ -570,7 +570,8 @@ def specificationsForKind(kind):
     # the monkeypatch re-configures breathe_default_project each time which was
     # foolishly relied on elsewhere and undoing that blunder requires undoing
     # all of the shenanigans that is configs.py...
-    ret.insert(0, ":project: " + configs._the_app.config.breathe_default_project)
+    if not any(":project:" in spec for spec in ret):
+        ret.insert(0, ":project: " + configs._the_app.config.breathe_default_project)
     return ret
 
 


### PR DESCRIPTION
Prevents multiple `:project:` tags from being added to a breathe directive.
Fixes the issue that PR #146 tries to prevent.