### PR TITLE
fix customSpecificationsMapping for kind 'class' and 'struct'

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@ Changelog
    :local:
    :backlinks: none
 
+v0.3.1
+----------------------------------------------------------------------------------------
+
+- Fix regression introduced by :pr:`139` where custom ``"class"`` and ``"struct"``
+  :data:`~exhale.configs.customSpecificationsMapping` were being overwritten
+  (:pr:`154`).
+
 v0.3.0
 ----------------------------------------------------------------------------------------
 

--- a/exhale/utils.py
+++ b/exhale/utils.py
@@ -562,9 +562,8 @@ def specificationsForKind(kind):
     # use the custom directives function
     if configs.customSpecificationsMapping:
         ret = configs.customSpecificationsMapping[kind]
-
     # otherwise, just provide class and struct
-    if kind == "class" or kind == "struct":
+    elif kind == "class" or kind == "struct":
         ret = [":members:", ":protected-members:", ":undoc-members:"]
 
     # the monkeypatch re-configures breathe_default_project each time which was


### PR DESCRIPTION
This PR fixes a bug in `exhale/utils.py:specificationsForKind(kind)`. When using a custom directive function with `customSpecificationsMapping`, the specifications for the kinds `struct` and `class` were overwritten.