### PR TITLE
Stop installing breathe from git for testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,10 +29,6 @@ deps =
     # this is just because I like to have color in my debugger...
     ipdb
 commands =
-    # TODO: waiting on breathe>=4.32.0 release; wheel needed for pip install breathe
-    {envpython} -m pip install wheel
-    {envpython} -m pip install --no-build-isolation git+https://github.com/michaeljones/breathe.git
-    # end TODO
     {envpython} -c 'import sphinx; print("\033[36;1mSphinx version: %s\033[0m" % sphinx.__version__)'
     {envpython} -c 'import breathe; print("\033[36;1mBreathe version: %s\033[0m" % breathe.__version__)'
     {envpython} -c 'import sys; print("\033[36;1mPython version: %d.%d.%d\033[0m" % sys.version_info[0:3])'


### PR DESCRIPTION
This is no longer necessary and wastes developer time.