### PR TITLE
Exclude generated conf.py from code coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,7 @@ include = [
     "exhale/**",
     "testing/**",
 ]
+omit = [
+    # Tests generate a conf.py that should not be included in code coverage.
+    "**/conf.py",
+]


### PR DESCRIPTION
Prevents build output from being littered with e.g.,

coverage/report.py:87:
CoverageWarning: Couldn't parse
'exhale/testing/projects/cpp_nesting/docs_TreeViewHierarchyTests_test_common/conf.py': No source for code:
'exhale/testing/projects/cpp_nesting/docs_TreeViewHierarchyTests_test_common/conf.py'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")