### PR TITLE
Add support for C++20 concepts

### DIFF
--- a/exhale/utils.py
+++ b/exhale/utils.py
@@ -106,6 +106,7 @@ def get_time():
 
 
 AVAILABLE_KINDS = [
+    "concept",
     "class",
     "define",
     "dir",
@@ -131,6 +132,7 @@ LEAF_LIKE_KINDS = [
     "define",
     "enum",
     "function",
+    "concept",
     "class",
     "struct",
     "typedef",
@@ -405,6 +407,8 @@ def qualifyKind(kind):
     +=============+==================+
     | "class"     | "Class"          |
     +-------------+------------------+
+    | "concept"   | "Concept"        |
+    +-------------+------------------+
     | "define"    | "Define"         |
     +-------------+------------------+
     | "enum"      | "Enum"           |
@@ -460,6 +464,8 @@ def kindAsBreatheDirective(kind):
     +-------------+--------------------+
     | Input Kind  | Output Directive   |
     +=============+====================+
+    | "concept"   | "doxygenconcept"   |
+    +-------------+--------------------+
     | "class"     | "doxygenclass"     |
     +-------------+--------------------+
     | "define"    | "doxygendefine"    |

--- a/testing/projects/CMakeLists.txt
+++ b/testing/projects/CMakeLists.txt
@@ -27,7 +27,7 @@ project(exhale-projects)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_BUILD_TYPE "Debug") # required for code coverage
@@ -116,6 +116,7 @@ endmacro()
 # List of projects to validate have code that actually compiles xD
 set(EXHALE_PROJECTS
   c_maths
+  cpp_concepts
   cpp_func_overloads
   cpp_long_names
   cpp_dir_underscores

--- a/testing/projects/cpp_concepts/CMakeLists.txt
+++ b/testing/projects/cpp_concepts/CMakeLists.txt
@@ -1,0 +1,22 @@
+########################################################################################
+# This file is dedicated to the public domain.  If your jurisdiction requires a        #
+# specific license:                                                                    #
+#                                                                                      #
+# Copyright (c) Stephen McDowell, 2017-2022                                            #
+# License:      CC0 1.0 Universal                                                      #
+# License Text: https://creativecommons.org/publicdomain/zero/1.0/legalcode            #
+########################################################################################
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+project(cpp-concepts LANGUAGES CXX)
+
+# "Header only library": add tests and include the directory
+target_sources(exhale-projects-unit-tests
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/tests.cpp
+)
+target_include_directories(exhale-projects-tests-interface
+  INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+add_open_cpp_coverage_source_dirs(include src)

--- a/testing/projects/cpp_concepts/__init__.py
+++ b/testing/projects/cpp_concepts/__init__.py
@@ -1,0 +1,1 @@
+# TODO(svenevs): add final hierarchies for the project and python tests once complete.

--- a/testing/projects/cpp_concepts/include/concepts/concepts.hpp
+++ b/testing/projects/cpp_concepts/include/concepts/concepts.hpp
@@ -1,0 +1,27 @@
+/***************************************************************************************
+ * This file is dedicated to the public domain.  If your jurisdiction requires a       *
+ * specific license:                                                                   *
+ *                                                                                     *
+ * Copyright (c) Stephen McDowell, 2017-2022                                           *
+ * License:      CC0 1.0 Universal                                                     *
+ * License Text: https://creativecommons.org/publicdomain/zero/1.0/legalcode           *
+ **************************************************************************************/
+#pragma once
+
+namespace concepts {
+
+    /// See https://en.cppreference.com/w/cpp/language/constraints
+    template <class T, class U>
+    concept Derived = std::is_base_of<U, T>::value;
+
+    /// A pure virtual base class that defines a useless interface.
+    struct Base {
+        /// The value of something.
+        virtual int value() const = 0;
+    };
+
+    /// Constrained function example made concrete from
+    /// https://en.cppreference.com/w/cpp/language/constraints
+    template <Derived<Base> T>
+    int get_value(const T& t) { return t.value(); }
+}  // namespace concepts

--- a/testing/projects/cpp_concepts/src/tests.cpp
+++ b/testing/projects/cpp_concepts/src/tests.cpp
@@ -1,0 +1,21 @@
+/***************************************************************************************
+ * This file is dedicated to the public domain.  If your jurisdiction requires a       *
+ * specific license:                                                                   *
+ *                                                                                     *
+ * Copyright (c) Stephen McDowell, 2017-2022                                           *
+ * License:      CC0 1.0 Universal                                                     *
+ * License Text: https://creativecommons.org/publicdomain/zero/1.0/legalcode           *
+ **************************************************************************************/
+#include <catch2/catch.hpp>
+
+/* ================================================================================== */
+
+#include <concepts/concepts.hpp>
+TEST_CASE( "concepts.hpp", "[cpp-concepts]" ) {
+    struct Concrete : public concepts::Base {
+        int value() const { return 11; }
+    };
+    Concrete c;
+
+    REQUIRE(concepts::get_value(c) == 11);
+}


### PR DESCRIPTION
CC @lums658 refs #160 I couldn't push to that branch (I think because it's the main branch of your repo), I'm sorry for the very long delay.  In order to support C++ concepts I needed to fix the testing framework for doxygen 1.9.x in order to actually test for this.  This one will take me some time to flesh out entirely (there's a handful of test framework changes which would be a nightmare for not me (well for me too, but way worse for anyone else)).

However, would you be willing to add some code to the newly created `testing/projects/cpp_concepts/include/concepts/concepts.hpp` and associated usages (where applicable) in `src/tests.cpp`?  The `tests.cpp` exists mostly to guarantee that anything added in `concepts.hpp` actually compiles.  The infrastructure is up, but it would be really helpful to have a more exhaustive list of  concepts code -- I'm not up to speed, just anything that would stress test doxygen / breathe from a documentation perspective.  Note the testing code license is CC0 (please add yourself to the license at the top though!).  Only other rule for code there is keep it PG-13, but otherwise the content (or docs) are less than meaningful anywhere else :wink:

I get the impression it would be fairly easy for you to PR to this branch with some nice modern concepts code there :pray:  

There's definitely no rush ... it'll take me some time to finalize things (I anticipate CI being troublesome here), but after the code is in place I will be able to inspect the implementation / create unit tests for the project.  Having the test project in place helps me look at the output of exhale and confirm it's working as desired.