### PR TITLE
Fix sphinx-bootstrap-theme styling

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@ Changelog
    :local:
    :backlinks: none
 
+v0.3.3
+----------------------------------------------------------------------------------------
+
+- Fix sphinx-bootstrap-theme styling, the introduction of the page hierarchies broke
+  the bootstrap tree for any project that does not use ``page``.  Solution is to only
+  select / apply the ``treeview`` functions if the id anchors are found (:pr:`167`).
+
 v0.3.2
 ----------------------------------------------------------------------------------------
 

--- a/exhale/data/treeView-bootstrap/bootstrap-treeview/apply-bootstrap-treview.js
+++ b/exhale/data/treeView-bootstrap/bootstrap-treeview/apply-bootstrap-treview.js
@@ -1,13 +1,26 @@
 $(document).ready(function() {
-    // apply the class view hierarchy
-    $("#class-treeView").treeview({
-        data: getClassViewTree(),
-        enableLinks: true
-    });
-
-    // apply the directory view hierarchy
-    $("#directory-treeView").treeview({
-        data: getDirectoryViewTree(),
-        enableLinks: true
-    });
+    // apply the page view hierarchy if it exists
+    var page_view = $("#page-treeView");
+    if (page_view.length) {
+        page_view.treeview({
+            data: getPageHierarchyTree(),
+            enableLinks: true
+        });
+    }
+    // apply the class view hierarchy if it exists
+    var class_view = $("#class-treeView");
+    if (class_view.length) {
+        class_view.treeview({
+            data: getClassViewTree(),
+            enableLinks: true
+        });
+    }
+    // apply the directory view hierarchy if it exists
+    var dir_view = $("#directory-treeView");
+    if (dir_view.length) {
+        dir_view.treeview({
+            data: getDirectoryViewTree(),
+            enableLinks: true
+        });
+    }
 });

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -3654,41 +3654,50 @@ class ExhaleRoot(object):
                                     */
                                     // Part 1: use linkColor as a parameter to bootstrap treeview
 
-                                    // apply the page view hierarchy
-                                    $("#{page_idx}").treeview({{
-                                        data: {page_func_name}(),
-                                        enableLinks: true,
-                                        color: linkColor,
-                                        showTags: {show_tags},
-                                        collapseIcon: "{collapse_icon}",
-                                        expandIcon: "{expand_icon}",
-                                        levels: {levels},
-                                        onhoverColor: "{onhover_color}"
-                                    }});
+                                    // apply the page view hierarchy if it exists
+                                    var page_h = $("#{page_idx}");
+                                    if (page_h.length) {{
+                                        page_h.treeview({{
+                                            data: {page_func_name}(),
+                                            enableLinks: true,
+                                            color: linkColor,
+                                            showTags: {show_tags},
+                                            collapseIcon: "{collapse_icon}",
+                                            expandIcon: "{expand_icon}",
+                                            levels: {levels},
+                                            onhoverColor: "{onhover_color}"
+                                        }});
+                                    }}
 
-                                    // apply the class view hierarchy
-                                    $("#{class_idx}").treeview({{
-                                        data: {class_func_name}(),
-                                        enableLinks: true,
-                                        color: linkColor,
-                                        showTags: {show_tags},
-                                        collapseIcon: "{collapse_icon}",
-                                        expandIcon: "{expand_icon}",
-                                        levels: {levels},
-                                        onhoverColor: "{onhover_color}"
-                                    }});
+                                    // apply the class view hierarchy if it exists
+                                    var class_h = $("#{class_idx}");
+                                    if (class_h.length) {{
+                                        class_h.treeview({{
+                                            data: {class_func_name}(),
+                                            enableLinks: true,
+                                            color: linkColor,
+                                            showTags: {show_tags},
+                                            collapseIcon: "{collapse_icon}",
+                                            expandIcon: "{expand_icon}",
+                                            levels: {levels},
+                                            onhoverColor: "{onhover_color}"
+                                        }});
+                                    }}
 
-                                    // apply the file view hierarchy
-                                    $("#{file_idx}").treeview({{
-                                        data: {file_func_name}(),
-                                        enableLinks: true,
-                                        color: linkColor,
-                                        showTags: {show_tags},
-                                        collapseIcon: "{collapse_icon}",
-                                        expandIcon: "{expand_icon}",
-                                        levels: {levels},
-                                        onhoverColor: "{onhover_color}"
-                                    }});
+                                    // apply the file view hierarchy if it exists
+                                    var file_h = $("#{file_idx}");
+                                    if (file_h.length) {{
+                                        file_h.treeview({{
+                                            data: {file_func_name}(),
+                                            enableLinks: true,
+                                            color: linkColor,
+                                            showTags: {show_tags},
+                                            collapseIcon: "{collapse_icon}",
+                                            expandIcon: "{expand_icon}",
+                                            levels: {levels},
+                                            onhoverColor: "{onhover_color}"
+                                        }});
+                                    }}
 
                                     // Part 2: override the style of the glyphicons by injecting some CSS
                                     $('<style type="text/css" id="exhaleTreeviewOverride">' +


### PR DESCRIPTION
The introduction of the page hierarchies broke the bootstrap tree for any project that does not use `page`.  Solution is to only select / apply the `treeview` functions if the id anchors are found.