### PR TITLE
Guarantee a newline always follows |exhale_lsh| backlinks

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@ Changelog
    :local:
    :backlinks: none
 
+v0.3.5
+----------------------------------------------------------------------------------------
+
+- Fix a bug (:issue:`171`) where some generated pages are missing a blank line (before
+  the heading markup, after the backlink to the parent directory) resulting in warnings
+  from sphinx (:pr:`172`).
+
 v0.3.4
 ----------------------------------------------------------------------------------------
 

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -3236,7 +3236,7 @@ class ExhaleRoot(object):
 
                             .. |exhale_lsh| unicode:: U+021B0 .. UPWARDS ARROW WITH TIP LEFTWARDS
 
-                        '''.format(
+                        '''.format(  # NOTE: newline required at end (#171)
                             link=link_declaration,
                             heading=prog_title,
                             heading_mark=utils.heading_mark(
@@ -3410,7 +3410,8 @@ class ExhaleRoot(object):
                             |exhale_lsh| :ref:`Parent directory <{parent_link}>` (``{parent_name}``)
 
                             .. |exhale_lsh| unicode:: U+021B0 .. UPWARDS ARROW WITH TIP LEFTWARDS
-                        '''.format(
+
+                        '''.format(  # NOTE: newline required at end (#171)
                             parent_link=f.parent.link_name, parent_name=f.parent.name
                         )))
 
@@ -3549,7 +3550,8 @@ class ExhaleRoot(object):
                 |exhale_lsh| :ref:`Parent directory <{parent_link}>` (``{parent_name}``)
 
                 .. |exhale_lsh| unicode:: U+021B0 .. UPWARDS ARROW WITH TIP LEFTWARDS
-            '''.format(
+
+            '''.format(  # NOTE: newline required at end (#171)
                 parent_link=node.parent.link_name, parent_name=node.parent.name
             ))
         else:

--- a/testing/hierarchies.py
+++ b/testing/hierarchies.py
@@ -924,10 +924,16 @@ def _compare_children(hierarchy_type, test, test_child, exhale_child):
                     |exhale_lsh| :ref:`Return to documentation for file <{file_link}>` (``{file_location}``)
 
                     .. |exhale_lsh| unicode:: U+021B0 .. UPWARDS ARROW WITH TIP LEFTWARDS
+
                 ''').format(
                     file_link=exhale_child.link_name,
                     file_location=exhale_child.location
                 )
+                # NOTE: see #171
+                test.assertTrue(
+                    program_back_link.endswith("S\n\n"),
+                    "Test setup failure, trailing newlines are expected.")
+
                 with codecs.open(program_listing_path, "r", "utf-8") as pl_file:
                     desired_lines = []
                     for line in pl_file:
@@ -973,9 +979,14 @@ def _compare_children(hierarchy_type, test, test_child, exhale_child):
                     |exhale_lsh| :ref:`Parent directory <{parent_link}>` (``{parent_name}``)
 
                     .. |exhale_lsh| unicode:: U+021B0 .. UPWARDS ARROW WITH TIP LEFTWARDS
+
                 '''.format(
                     parent_link=parent_link_name, parent_name=parent_name
                 ))
+                # NOTE: see #171
+                test.assertTrue(
+                    parent_reference.endswith("S\n\n"),
+                    "Test setup failure, trailing newlines are expected.")
 
                 # Verify that both files and directories link to their directory parent
                 test.assertTrue(


### PR DESCRIPTION
Fixes #171.

Some pages do not have any additional information between the
parent backlink and the title heading.  In this event there is no
newline between the comment and the heading markup resulting in
warnings from sphinx.