### PR TITLE
allow sphinx versions 5.x

### DIFF
--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -65,7 +65,7 @@ jobs:
         env:
           # NOTE: in the future, we may want to use a larger matrix with more
           # combinations of sphinx and breathe, but for now it is not necessary.
-          SPHINX_VERSION: '>=4<6'
+          SPHINX_VERSION: '>=4<7'
         run: |
           tox -e py -- --cov-report xml:coverage.xml --cov
       - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx 4.x

--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -65,7 +65,7 @@ jobs:
         env:
           # NOTE: in the future, we may want to use a larger matrix with more
           # combinations of sphinx and breathe, but for now it is not necessary.
-          SPHINX_VERSION: '>=4<5'
+          SPHINX_VERSION: '>=4<6'
         run: |
           tox -e py -- --cov-report xml:coverage.xml --cov
       - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx 4.x

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ packages = find:
 install_requires =
     # From breathe==4.32.0
     docutils>=0.12
-    Sphinx>=3.0,<6
+    Sphinx>=3.0,<7
     # For exhale
     breathe>=4.32.0
     beautifulsoup4

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ packages = find:
 install_requires =
     # From breathe==4.32.0
     docutils>=0.12
-    Sphinx>=3.0,<5
+    Sphinx>=3.0,<6
     # For exhale
     breathe>=4.32.0
     beautifulsoup4


### PR DESCRIPTION
AFAICT there was no real need to limit the sphinx version to `<5`, right?
In general, wouldn't it also suffice to transitively depend on the sphinx versions via `breathe`'s requirements?