### PR TITLE
Do not crash on toConsole when kind is not known

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,12 @@ Changelog
    :local:
    :backlinks: none
 
+v0.3.7
+----------------------------------------------------------------------------------------
+
+- Fix a bug where an unknown node kind, such as concepts, would cause a crash due to a
+  missing color in the console (:issue:`195`, :pr:`196`).
+
 v0.3.6
 ----------------------------------------------------------------------------------------
 

--- a/exhale/graph.py
+++ b/exhale/graph.py
@@ -565,7 +565,7 @@ class ExhaleNode(object):
         indent = "  " * level
         utils.verbose_log("{indent}- [{kind}]: {name}".format(
             indent=indent,
-            kind=utils._use_color(self.kind, fmt_spec[self.kind], sys.stderr),
+            kind=utils._use_color(self.kind, fmt_spec.get(self.kind, utils.AnsiColors.BOLD_RED), sys.stderr),
             name=self.name
         ))
         # files are children of directories, the file section will print those children


### PR DESCRIPTION
This fixes #195 and perhaps will prevent crashes in the future, should the node kind not be known.

This PR doesn't even attempt to properly support concepts, just allows the documentation building process to go through.