### PR TITLE
Add dependabot for Github Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
### Change

Github Actions maintenance must be done manually by inspecting the GH action page and compare it with your current workflows.
This can be done by the dependabot.

To avoid the well known dependabot PR spam:

* only run for GH Actions
* the bot only runs once a month
* found updates will be grouped to one single PR.


### Why maintance for GH Actions required?

They run on node and will be deprecated and stop working after time.
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

### Benefit

Avoids manual chore like #199

### Disadvantage

The dependabot does **not** migrations. So still read changelog ;-)