### PR TITLE
Fix GH Actions fail-fast usage

### DIFF
--- a/.github/workflows/test_extras.yaml
+++ b/.github/workflows/test_extras.yaml
@@ -17,8 +17,6 @@ jobs:
   build_docs_linkcheck:
     name: Docs / Linkcheck
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
@@ -43,8 +41,6 @@ jobs:
   build_flake8:
     name: Flake8
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
@@ -62,8 +58,6 @@ jobs:
   build_dist:
     name: Packaging
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/testing_projects.yaml
+++ b/.github/workflows/testing_projects.yaml
@@ -17,8 +17,6 @@ jobs:
   build_linux:
     name: Linux
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4
@@ -62,8 +60,6 @@ jobs:
   build_windows:
     name: Windows
     runs-on: windows-latest
-    strategy:
-      fail-fast: false
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`fai-fast` just works with `matrix`.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast