### PR TITLE
Fix current tests

### DIFF
--- a/.github/actions/sphinx_version_tests/action.yml
+++ b/.github/actions/sphinx_version_tests/action.yml
@@ -1,0 +1,49 @@
+# File: .github/actions/test-sphinx-8x/action.yml
+name: 'Sphinx versions'
+description: 'Run tests and upload code coverage for Sphinx 8.x'
+inputs:
+  python-version:
+    description: 'Python version to use'
+    required: true
+  os:
+    description: 'Operating system'
+    required: true
+  sphinx_version_range:
+    description: 'Sphinx version range to test'
+    required: true
+  codecov_token:
+    description: 'Codecov token'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+    - name: Install Python Tools
+      shell: bash
+      run: |
+        pip install tox codecov coverage
+    - name: Test Python ${{ inputs.python-version }} / sphinx ${{ inputs.sphinx_version_range }}
+      shell: bash
+      env:
+        SPHINX_VERSION: ${{ inputs.sphinx_version_range }}
+      run: |
+        tox -e py -- --cov-report xml:coverage.xml --cov
+    - name: Upload Code Coverage for Python ${{ inputs.python-version }} / sphinx ${{ inputs.sphinx_version_range }}
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ inputs.codecov_token }}
+        fail_ci_if_error: true
+        file: coverage.xml
+        name: "[GHA] ${{ inputs.os }}-py${{ inputs.python-version }}-sphinx8.x"
+        plugins: pycoverage,xcode
+    # Don't let code coverage utilities share anything, force clean it all.
+    - name: Cleanup Python ${{ inputs.python-version }} Testing / Coverage Artifacts
+      shell: bash
+      run: |
+        mv .gitignore nolongerignored
+        git clean -n
+        git clean -f
+        git reset --hard

--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -85,14 +85,14 @@ jobs:
           os: ${{ matrix.os }}
           sphinx_version_range: '>=7,<7.2'
           codecov_token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Test Python ${{ matrix.python-version }} / sphinx 8.x
-        uses: ./.github/actions/sphinx_version_tests
-        # sphinx >=8 needs py >= 3.10
-        if: matrix.python-version != '3.8' && matrix.python-version != '3.9'
-        with:
-          python-version: ${{ matrix.python-version }}
-          os: ${{ matrix.os }}
-          sphinx_version_range: '>=8,<9'
-          codecov_token: ${{ secrets.CODECOV_TOKEN }}
+# TODO this looks like more substantial work to get going
+#      - name: Test Python ${{ matrix.python-version }} / sphinx 8.x
+#        uses: ./.github/actions/sphinx_version_tests
+#        # sphinx >=8 needs py >= 3.10
+#        if: matrix.python-version != '3.8' && matrix.python-version != '3.9'
+#        with:
+#          python-version: ${{ matrix.python-version }}
+#          os: ${{ matrix.os }}
+#          sphinx_version_range: '>=8,<9'
+#          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -25,7 +25,7 @@ jobs:
         os: [ macos-latest, ubuntu-latest, windows-latest ]
         python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
     env:
-      MINIMUM_SUPPORTED_SPHINX_VERSION: '4.3.2'
+      MINIMUM_SUPPORTED_SPHINX_VERSION: '5.0.2'
     steps:
       - uses: actions/checkout@v4
       ##################################################################################
@@ -53,7 +53,7 @@ jobs:
       - name: Install Python Tools
         run: |
           pip install tox codecov coverage
-      # Sphinx 4.3.2 ###################################################################
+      # Sphinx MINIMUM_SUPPORTED_SPHINX_VERSION ###################################################################
       - name: Test Python ${{ matrix.python-version }} / sphinx==${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}
         env:
           # NOTE: this is the current minimum supported.

--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Doxygen (Windows)
         if: contains(matrix.os, 'windows')
         uses: ssciwr/doxygen-install@v1
-          with:
+        with:
           version: "1.9.6"
       ##################################################################################
       - name: Doxygen Version Dump

--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -130,5 +130,21 @@ jobs:
           file: coverage.xml
           name: "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx7.x"
           plugins: pycoverage,xcode
-
+      # Sphinx 8.x #####################################################################
+      - name: Test Python ${{ matrix.python-version }} / sphinx 8.x
+        env:
+          # Test sphinx 8.x.
+          # TODO: breathe does not currently support later sphinx.
+          # https://github.com/svenevs/exhale/issues/203#issuecomment-1773060684
+          SPHINX_VERSION: '>=8,<9'
+        run: |
+          tox -e py -- --cov-report xml:coverage.xml --cov
+      - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx 8.x
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          file: coverage.xml
+          name: "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx8.x"
+          plugins: pycoverage,xcode
 

--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -53,98 +53,46 @@ jobs:
       - name: Install Python Tools
         run: |
           pip install tox codecov coverage
-      # Sphinx MINIMUM_SUPPORTED_SPHINX_VERSION ###################################################################
+
       - name: Test Python ${{ matrix.python-version }} / sphinx==${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}
-        env:
-          # NOTE: this is the current minimum supported.
-          SPHINX_VERSION: '==${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}'
-        run: |
-          tox -e py -- --cov-report xml:coverage.xml --cov
-      - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx==${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}
-        uses: codecov/codecov-action@v4
+        uses: ./.github/actions/sphinx_version_tests
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          file: coverage.xml
-          name: "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}"
-          # this the inverted translation of `-X gcov`
-          plugins: pycoverage,xcode
-      # Don't let code coverage utilities share anything, force clean it all.
-      - name: Cleanup Python ${{ matrix.python-version }} Testing / Coverage Artifacts
-        run: |
-          mv .gitignore nolongerignored
-          git clean -n
-          git clean -f
-          git reset --hard
-      # Sphinx 5.x #####################################################################
+          python-version: ${{ matrix.python-version }}
+          os: ${{ matrix.os }}
+          sphinx_version_range: '==${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Test Python ${{ matrix.python-version }} / sphinx 5.x
-        env:
-          # Test sphinx 5.x.
-          SPHINX_VERSION: '>=5,<6'
-        run: |
-          tox -e py -- --cov-report xml:coverage.xml --cov
-      - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx 5.x
-        uses: codecov/codecov-action@v4
+        uses: ./.github/actions/sphinx_version_tests
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          file: coverage.xml
-          name: "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx5.x"
-          plugins: pycoverage,xcode
-      # Don't let code coverage utilities share anything, force clean it all.
-      - name: Cleanup Python ${{ matrix.python-version }} Testing / Coverage Artifacts
-        run: |
-          mv .gitignore nolongerignored
-          git clean -n
-          git clean -f
-          git reset --hard
-      # Sphinx 6.x #####################################################################
+          python-version: ${{ matrix.python-version }}
+          os: ${{ matrix.os }}
+          sphinx_version_range: '>=5,<6'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Test Python ${{ matrix.python-version }} / sphinx 6.x
-        env:
-          # Test sphinx 6.x.
-          SPHINX_VERSION: '>=6,<7'
-        run: |
-          tox -e py -- --cov-report xml:coverage.xml --cov
-      - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx 6.x
-        uses: codecov/codecov-action@v4
+        uses: ./.github/actions/sphinx_version_tests
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          file: coverage.xml
-          name: "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx6.x"
-          plugins: pycoverage,xcode
-      # Sphinx 7.x #####################################################################
+          python-version: ${{ matrix.python-version }}
+          os: ${{ matrix.os }}
+          sphinx_version_range: '>=6,<7'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Test Python ${{ matrix.python-version }} / sphinx 7.x
-        env:
-          # Test sphinx 7.x.
-          # TODO: breathe does not currently support later sphinx.
-          # https://github.com/svenevs/exhale/issues/203#issuecomment-1773060684
-          SPHINX_VERSION: '>=7,<7.2'
-        run: |
-          tox -e py -- --cov-report xml:coverage.xml --cov
-      - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx 7.x
-        uses: codecov/codecov-action@v4
+        uses: ./.github/actions/sphinx_version_tests
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          file: coverage.xml
-          name: "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx7.x"
-          plugins: pycoverage,xcode
-      # Sphinx 8.x #####################################################################
+          python-version: ${{ matrix.python-version }}
+          os: ${{ matrix.os }}
+          sphinx_version_range: '>=7,<7.2'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Test Python ${{ matrix.python-version }} / sphinx 8.x
-        env:
-          # Test sphinx 8.x.
-          # TODO: breathe does not currently support later sphinx.
-          # https://github.com/svenevs/exhale/issues/203#issuecomment-1773060684
-          SPHINX_VERSION: '>=8,<9'
-        run: |
-          tox -e py -- --cov-report xml:coverage.xml --cov
-      - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx 8.x
-        uses: codecov/codecov-action@v4
+        uses: ./.github/actions/sphinx_version_tests
+        # sphinx >=8 needs py >= 3.10
+        if: matrix.python-version != '3.8' && matrix.python-version != '3.9'
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
-          file: coverage.xml
-          name: "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx8.x"
-          plugins: pycoverage,xcode
+          python-version: ${{ matrix.python-version }}
+          os: ${{ matrix.os }}
+          sphinx_version_range: '>=8,<9'
+          codecov_token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -61,8 +61,14 @@ jobs:
         run: |
           tox -e py -- --cov-report xml:coverage.xml --cov
       - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx==${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}
-        run: |
-          codecov --required -X gcov -f coverage.xml --name "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}"
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          file: coverage.xml
+          name: "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}"
+          # this the inverted translation of `-X gcov`
+          plugins: pycoverage,xcode
       # Don't let code coverage utilities share anything, force clean it all.
       - name: Cleanup Python ${{ matrix.python-version }} Testing / Coverage Artifacts
         run: |
@@ -78,8 +84,13 @@ jobs:
         run: |
           tox -e py -- --cov-report xml:coverage.xml --cov
       - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx 5.x
-        run: |
-          codecov --required -X gcov -f coverage.xml --name "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx5.x"
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          file: coverage.xml
+          name: "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx5.x"
+          plugins: pycoverage,xcode
       # Don't let code coverage utilities share anything, force clean it all.
       - name: Cleanup Python ${{ matrix.python-version }} Testing / Coverage Artifacts
         run: |
@@ -95,8 +106,13 @@ jobs:
         run: |
           tox -e py -- --cov-report xml:coverage.xml --cov
       - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx 6.x
-        run: |
-          codecov --required -X gcov -f coverage.xml --name "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx6.x"
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          file: coverage.xml
+          name: "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx6.x"
+          plugins: pycoverage,xcode
       # Sphinx 7.x #####################################################################
       - name: Test Python ${{ matrix.python-version }} / sphinx 7.x
         env:
@@ -107,6 +123,12 @@ jobs:
         run: |
           tox -e py -- --cov-report xml:coverage.xml --cov
       - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx 7.x
-        run: |
-          codecov --required -X gcov -f coverage.xml --name "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx7.x"
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          file: coverage.xml
+          name: "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx7.x"
+          plugins: pycoverage,xcode
+
 

--- a/.github/workflows/test_python.yaml
+++ b/.github/workflows/test_python.yaml
@@ -22,8 +22,10 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+    env:
+      MINIMUM_SUPPORTED_SPHINX_VERSION: '4.3.2'
     steps:
       - uses: actions/checkout@v4
       ##################################################################################
@@ -52,15 +54,15 @@ jobs:
         run: |
           pip install tox codecov coverage
       # Sphinx 4.3.2 ###################################################################
-      - name: Test Python ${{ matrix.python-version }} / sphinx==4.3.2
+      - name: Test Python ${{ matrix.python-version }} / sphinx==${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}
         env:
           # NOTE: this is the current minimum supported.
-          SPHINX_VERSION: '==4.3.2'
+          SPHINX_VERSION: '==${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}'
         run: |
           tox -e py -- --cov-report xml:coverage.xml --cov
-      - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx==4.3.2
+      - name: Upload Code Coverage for Python ${{ matrix.python-version }} / sphinx==${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}
         run: |
-          codecov --required -X gcov -f coverage.xml --name "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx4.3.2"
+          codecov --required -X gcov -f coverage.xml --name "[GHA] ${{ matrix.os }}-py${{ matrix.python-version }}-sphinx${{ env.MINIMUM_SUPPORTED_SPHINX_VERSION }}"
       # Don't let code coverage utilities share anything, force clean it all.
       - name: Cleanup Python ${{ matrix.python-version }} Testing / Coverage Artifacts
         run: |

--- a/.github/workflows/testing_projects.yaml
+++ b/.github/workflows/testing_projects.yaml
@@ -55,7 +55,7 @@ jobs:
           cmake ..
           make -j
           make coverage-xml
-          codecov -X gcov -f .\coverage.xml --name linux_cxx
+          codecov -X gcov -f ./coverage.xml --name linux_cxx
 
   build_windows:
     name: Windows

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+---
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.1
+  hooks:
+  - id: actionlint
+- repo: https://github.com/koalaman/shellcheck-precommit
+  rev: v0.10.0
+  hooks:
+  - id: shellcheck
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.6.0
+  hooks:
+  - id: no-commit-to-branch
+    args: [--branch, master]
+  - id: trailing-whitespace
+  - id: check-added-large-files
+  - id: check-case-conflict
+  - id: check-yaml
+  - id: check-xml
+  - id: check-json
+  - id: check-toml
+  - id: check-symlinks
+  - id: fix-byte-order-marker

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -70,7 +70,7 @@ and the following (simplified, read the Sphinx docs for the full story) occurs:
    - Exhale requests notification of the `builder-inited`__ event, which is the first
      event where the configuration variables have been populated.
 
-     __ https://www.sphinx-doc.org/en/master/extdev/appapi.html#event-builder-inited
+     __ https://www.sphinx-doc.org/en/master/extdev/event_callbacks.html#event-builder-inited
 
    - It would be nice to one-day support incremental builds and a clean target, but at
      this time I have no idea how to do these.
@@ -86,7 +86,7 @@ and the following (simplified, read the Sphinx docs for the full story) occurs:
 
         Even if you don't have a solution, it would be great to hear of ideas!
 
-     __ https://www.sphinx-doc.org/en/master/extdev/appapi.html#event-env-get-outdated
+     __ https://www.sphinx-doc.org/en/master/extdev/event_callbacks.html#event-env-get-outdated
 
 3. Now that the extensions have been setup, the rest of ``conf.py`` is processed.  For
    all intensive purposes, you can assume that as soon as this is complete is when

--- a/exhale/data/treeView-bootstrap/bootstrap-treeview/LICENSE
+++ b/exhale/data/treeView-bootstrap/bootstrap-treeview/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Jonathan Miles 
+   Copyright 2017 Jonathan Miles
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ skip_install = true
 # This way, if the variable is not set, it uses the latest version.
 deps =
     # requirements for exhale
-    sphinx{env:SPHINX_VERSION:>=4.3.2}
+    sphinx{env:SPHINX_VERSION:>=5.0.2}
     breathe{env:BREATHE_VERSION:>=4.33.1}
     beautifulsoup4
     # NOTE: for dev convenience, see https://github.com/svenevs/exhale/issues/131


### PR DESCRIPTION
The current tests [now all pass in my fork](https://github.com/renefritze/exhale/pull/3/checks). Couple of notes:

1. I've moved to using the codecov action because the deprecated upload immeadiately ran into rate limiting. This will need a `CODECOV_TOKEN` repo secret
2. If you're not happy with the new lowest supported version, it's probably not too hard to fix the tests for it. The errors just looked like SPhinx internals that I knew nothing about.
3. I've added a mostly unintrusive pre-commit setup, mostly to get actionlint going. Would you be happy with a more substantial config that also does linting and formatting (with ruff)?
4. Locally the Fortran `CPPFOrtranMixed.tests_hierarchies` fails. For some reason the checked functions have an additional `intent(in)` argument. I've just ignored that. 
